### PR TITLE
use nais-team-app instead of srvnais PAT

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,7 +62,12 @@ jobs:
       - name: Create tag
         run: |
           git tag ${{ needs.set-version.outputs.version }}
-
+      - uses: navikt/github-app-token-generator@v1
+        id: get-homebrew-token
+        with:
+          private-key: ${{ secrets.NAIS_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.NAIS_APP_ID }}
+          repo: nais/homebrew-tap
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -71,6 +76,7 @@ jobs:
           args: release -f .goreleaser.yml --rm-dist --debug
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUSH_TOKEN: ${{ steps.get-homebrew-token.outputs.token }}
 
       - uses: navikt/github-app-token-generator@v1
         id: get-token


### PR DESCRIPTION
more info: https://github.com/apps/nais-team-app

i should have added the necessary secrets (`NAIS_APP_PRIVATE_KEY`, and `NAIS_APP_ID`), but it's probably smart to have a look at the [repository secrets](../settings/secrets/actions) and verify their existence before merging this.

also, i removed PUSH_TOKEN from the goreleaser step. i couldn't find the env variable documented anywhere in the goreleaser project, and i want to eliminate the use of `SRVNAIS_REPO_PUSH_PAT`