### PR TITLE
Prefix cluster names when tenant is not selected, and print something while working

### DIFF
--- a/cmd/root/naas/kubeconfig.go
+++ b/cmd/root/naas/kubeconfig.go
@@ -67,7 +67,7 @@ var kubeconfigCmd = &cobra.Command{
 			includeManagement: viper.GetBool(cmd.IncludeManagementFlag),
 		}
 
-		kcs.prefix = kcs.tenant != ""
+		kcs.prefix = kcs.tenant == ""
 
 		return kcs.Run(ctx)
 	},
@@ -98,4 +98,8 @@ func gcloudEmail(ctx context.Context) (string, error) {
 		return "", err
 	}
 	return cfg.Configuration.Properties.Core.Account, nil
+}
+
+func (p project) String() string {
+	return fmt.Sprintf("%s:%s (%s)", p.Tenant, p.Name, p.ID)
 }

--- a/cmd/root/naas/kubeconfigsync.go
+++ b/cmd/root/naas/kubeconfigsync.go
@@ -49,6 +49,7 @@ func (k *kubeConfigSync) Run(ctx context.Context) error {
 
 	clusters := []clusterEntry{}
 	for _, project := range projects {
+		fmt.Printf("Getting clusters for %s ...\n", project)
 		cluster, err := k.clusters(ctx, project)
 		if err != nil {
 			return err
@@ -152,6 +153,7 @@ func (k *kubeConfigSync) clusters(ctx context.Context, project project) ([]clust
 		if k.prefix {
 			name = project.Tenant + "-" + strings.TrimPrefix(name, "nais-")
 		}
+		fmt.Printf("Adding cluster %s\n", name)
 		ret = append(ret, clusterEntry{
 			Name:     name,
 			Endpoint: "https://" + cluster.Endpoint,
@@ -197,6 +199,7 @@ func (k *kubeConfigSync) onpremClusters(ctx context.Context, project project) ([
 		if k.prefix {
 			name = project.Tenant + "-" + strings.TrimPrefix(name, "nais-")
 		}
+		fmt.Printf("Adding onprem cluster %s\n", name)
 		ret = append(ret, clusterEntry{
 			Name:     name,
 			Endpoint: config.URL,


### PR DESCRIPTION
To me, the prefix logic is either reversed from what would be useful, or should always be used.

When getting all tenants, the clusters need to get tenant prefixes, or they get mixed and impossible to use.
Might be the clusters should get tenant prefixes always, not sure what the reasoning for the current logic was ...?
