### PR TITLE
Postgres/revoke

### DIFF
--- a/cmd/root/postgres/config.go
+++ b/cmd/root/postgres/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	proxy     *cobra.Command
 	grant     *cobra.Command
 	prepare   *cobra.Command
+	revoke    *cobra.Command
 	psql      *cobra.Command
 	users     *cobra.Command
 	listUsers *cobra.Command
@@ -41,6 +42,7 @@ func NewConfig() *Config {
 		proxy:     proxyCmd,
 		grant:     grantCmd,
 		prepare:   prepareCmd,
+		revoke:    revokeCmd,
 		psql:      psqlCmd,
 		users:     usersCommand,
 		listUsers: listUsersCmd,

--- a/cmd/root/postgres/dbinfo.go
+++ b/cmd/root/postgres/dbinfo.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
 	"strings"
 
 	naisalpha1 "github.com/nais/liberator/pkg/apis/nais.io/v1alpha1"
@@ -215,4 +216,13 @@ type ConnectionInfo struct {
 
 func (c *ConnectionInfo) ConnectionString() string {
 	return fmt.Sprintf("host=%v user=%v dbname=%v password=%v sslmode=disable", c.host, c.username, c.dbName, c.password)
+}
+
+func getSecretDataValue(secret *corev1.Secret, suffix string) string {
+	for name, val := range secret.Data {
+		if strings.HasSuffix(name, suffix) {
+			return string(val)
+		}
+	}
+	return ""
 }

--- a/cmd/root/postgres/prepare.go
+++ b/cmd/root/postgres/prepare.go
@@ -8,12 +8,10 @@ import (
 	"os"
 	"strings"
 
+	_ "github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/dialers/postgres"
 	"github.com/nais/cli/cmd"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	corev1 "k8s.io/api/core/v1"
-
-	_ "github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/dialers/postgres"
 )
 
 const prepareHelp = `Prepare will prepare the postgres instance by connecting using the
@@ -76,15 +74,6 @@ var prepareCmd = &cobra.Command{
 
 		return nil
 	},
-}
-
-func getSecretDataValue(secret *corev1.Secret, suffix string) string {
-	for name, val := range secret.Data {
-		if strings.HasSuffix(name, suffix) {
-			return string(val)
-		}
-	}
-	return ""
 }
 
 func setGrant(sql string, allPrivs bool) string {

--- a/cmd/root/postgres/revoke.go
+++ b/cmd/root/postgres/revoke.go
@@ -1,0 +1,76 @@
+package postgres
+
+import (
+	"bufio"
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	_ "github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/dialers/postgres"
+	"github.com/nais/cli/cmd"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const revokeHelp = `Revoke will revoke the role 'cloudsqliamuser' access to the
+tables in the postgres instance. This is done by connecting using the application
+credentials and modify the permissions on the public schema.
+
+This operation is only required to run once for each postgresql instance.`
+
+var revokeDdlStatements = []string{
+	"alter default privileges in schema public revoke ALL on tables from cloudsqliamuser;",
+	"alter default privileges in schema public revoke ALL on sequences from cloudsqliamuser;",
+	"revoke ALL on all tables in schema public from cloudsqliamuser;",
+	"revoke ALL on all sequences in schema public from cloudsqliamuser;",
+}
+
+var revokeCmd = &cobra.Command{
+	Use:   "revoke [app-name] [flags]",
+	Short: "Revoke access to your postgres instance for the role 'cloudsqliamuser'",
+	Long:  revokeHelp,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(command *cobra.Command, args []string) error {
+		appName := args[0]
+		namespace := viper.GetString(cmd.NamespaceFlag)
+		context := viper.GetString(cmd.ContextFlag)
+		databaseName := viper.GetString(cmd.DatabaseFlag)
+		dbInfo, err := NewDBInfo(appName, namespace, context, databaseName)
+		if err != nil {
+			return err
+		}
+
+		ctx := command.Context()
+
+		fmt.Println(revokeHelp)
+
+		fmt.Print("\nAre you sure you want to continue (y/N): ")
+		input := bufio.NewScanner(os.Stdin)
+		input.Scan()
+		if !strings.EqualFold(strings.TrimSpace(input.Text()), "y") {
+			return fmt.Errorf("cancelled by user")
+		}
+
+		connectionInfo, err := dbInfo.DBConnection(ctx)
+		if err != nil {
+			return err
+		}
+
+		db, err := sql.Open("cloudsqlpostgres", connectionInfo.ConnectionString())
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer db.Close()
+
+		for _, ddl := range revokeDdlStatements {
+			_, err = db.ExecContext(ctx, ddl)
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		return nil
+	},
+}


### PR DESCRIPTION
`nais postgres revoke $db`.

Revokes the privileges given to the role cloudsqliamuser. Does not remove access for users to log in to the database or the
roles/cloudsql.admin given to the user in GCP console.