### PR TITLE
fall-through for other binaries

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"log"
 	"os"
+	"os/exec"
 
 	"github.com/nais/cli/cmd/debugcmd"
 
@@ -48,8 +49,39 @@ func Run() {
 
 	m.CollectCommandHistogram(app.Commands)
 
+	if len(os.Args) > 1 {
+		if !isCommand(os.Args[1], app.Commands) {
+			binaryName := "nais-" + os.Args[1]
+			if err := runOtherBin(binaryName, os.Args[2:]); err != nil {
+			}
+		}
+	}
+
 	err := app.Run(os.Args)
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+func isCommand(command string, commands []*cli.Command) bool {
+	for _, cmd := range commands {
+		if cmd.Name == command {
+			return true
+		}
+	}
+	return false
+}
+
+func runOtherBin(binary string, args []string) error {
+	binaryPath, err := exec.LookPath(binary)
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(binaryPath, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+
+	return cmd.Run()
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -49,6 +49,11 @@ func Run() {
 
 	m.CollectCommandHistogram(app.Commands)
 
+	// first, before running the cli propper we check if the argv[1] contains a
+	// thing that is named nais-argv[1]. if so, we run that with the rest of the
+	// argument string and then exit.
+	// This gives us and our users a nice way of extending the cli by just shipping other
+	// binaries. this is spiritually what git and others do.
 	if len(os.Args) > 1 {
 		if !isCommand(os.Args[1], app.Commands) {
 			binaryName := "nais-" + os.Args[1]

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -52,7 +52,9 @@ func Run() {
 	if len(os.Args) > 1 {
 		if !isCommand(os.Args[1], app.Commands) {
 			binaryName := "nais-" + os.Args[1]
-			if err := runOtherBin(binaryName, os.Args[2:]); err != nil {
+			if err := runOtherBin(binaryName, os.Args[2:]); err == nil {
+				os.Exit(0)
+
 			}
 		}
 	}


### PR DESCRIPTION
If you have a binary, nais-foo in your path and you call nais foo the cli will run nais-foo with all the rest of the args provided. 
This gives a bit of user extension capabilities and allows us to widen the ecosystem of how we do subcommands