### PR TITLE
fix: adjust the generated pseudo version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,8 +20,12 @@ jobs:
       - name: set version
         id: set-version
         run: |
-          echo Faking a Semantic Version
-          echo "version=2.0.0-$(date "+%Y%m%d%H%M")" >> ${GITHUB_OUTPUT}
+          TIMESTAMP=$(git show -s --format=%cd --date=format:%Y%m%d%H%M%S HEAD)
+          COMMIT_SHA=$(git rev-parse --short=12 HEAD)
+          VERSION="v2.0.0-${TIMESTAMP}-${COMMIT_SHA}"
+
+          echo "version=${VERSION}" >> ${GITHUB_OUTPUT}
+          echo "Pseudo semantic version: ${VERSION}"
 
   checks:
     strategy:

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -25,7 +25,7 @@ func newApplication(flags *root.Flags) *cli.Application {
 	return &cli.Application{
 		Name:    "nais",
 		Title:   "Nais CLI",
-		Version: version.Version + "-" + version.Commit,
+		Version: version.Version,
 		SubCommands: []*cli.Command{
 			login.Login(flags),
 			logout.Logout(flags),

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,3 @@
 package version
 
-var (
-	Version = "local"
-	Commit  = "uncommited"
-)
+var Version = "local"

--- a/mise.toml
+++ b/mise.toml
@@ -56,7 +56,7 @@ wait_for = ['fmt']
 run = """
 go build \
   -installsuffix cgo \
-  -ldflags "-s -w -X github.com/nais/cli/internal/version.Version=${VERSION:-local} -X github.com/nais/cli/internal/version.Commit=$(git rev-parse --short HEAD)" \
+  -ldflags "-s -w -X github.com/nais/cli/internal/version.Version=${VERSION:-local}" \
   -o bin/nais ./
 """
 


### PR DESCRIPTION
The generated version string should now be a valid pseudo version according to: https://go.dev/ref/mod#pseudo-versions