### PR TITLE
refactor(naisapi/auth): clean up implementations

### DIFF
--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -98,7 +98,7 @@ func Run(ctx context.Context, w io.Writer) error {
 	}
 
 	if err != nil {
-		if errors.Is(err, naisapi.ErrNotAuthenticated) {
+		if errors.Is(err, naisapi.ErrNeedsLogin) {
 			// TODO(tronghn): If tty; prompt for login (y/n)?
 			pterm.Error.Println("You are not logged in. Please run `nais auth login --nais` to authenticate.")
 		}

--- a/internal/auth/printaccesstoken/printaccesstoken.go
+++ b/internal/auth/printaccesstoken/printaccesstoken.go
@@ -28,11 +28,11 @@ func PrintAccessToken(parentFlags *flag.Auth) *naistrix.Command {
 				if err != nil {
 					return err
 				}
-				token, err := user.GetTokenSource().Token()
+				token, err := user.AccessToken()
 				if err != nil {
 					return err
 				}
-				out.Println(token.AccessToken)
+				out.Println(token)
 				return nil
 			}
 

--- a/internal/naisapi/auth/github.go
+++ b/internal/naisapi/auth/github.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"time"
 
+	"github.com/lestrrat-go/jwx/v3/jwt"
 	"golang.org/x/oauth2"
 )
 
@@ -18,69 +20,80 @@ func GithubActions(ctx context.Context) (*AuthenticatedUser, bool, error) {
 		return nil, false, nil
 	}
 
-	// TODO: this is temporary; should be derived from the token somehow
+	// TODO: tenant and domain should be derived from the token somehow
 	tenant := os.Getenv("NAIS_API_TENANT")
 	if tenant == "" {
 		return nil, false, fmt.Errorf("NAIS_API_TENANT must be set when using GitHub Actions authentication")
 	}
+	domain := "TODO"
 
-	ts := &githubActionsTokenSource{ctx, u, tok}
+	ts := githubTokenSource(ctx, u, tok)
 	token, err := ts.Token()
 	if err != nil {
 		return nil, false, fmt.Errorf("getting token from github actions: %w", err)
 	}
 
-	// TODO: this should be a oauth2.ReuseTokenSource that refreshes the token when expired
 	return &AuthenticatedUser{
-		TokenSource: oauth2.StaticTokenSource(token),
 		consoleHost: "console." + tenant + ".cloud.nais.io",
-		domain:      "TODO",
-		email:       "TODO",
+		domain:      domain,
+		ts:          oauth2.ReuseTokenSourceWithExpiry(token, ts, 30*time.Second),
 	}, true, nil
 }
 
-type githubActionsTokenSource struct {
-	ctx          context.Context
-	requestURL   string
-	requestToken string
-}
+func githubTokenSource(ctx context.Context, requestURL, requestToken string) oauth2.TokenSource {
+	return tokenSourceFunc(func() (*oauth2.Token, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("creating request: %w", err)
+		}
 
-func (g *githubActionsTokenSource) Token() (*oauth2.Token, error) {
-	req, err := http.NewRequestWithContext(g.ctx, http.MethodGet, g.requestURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
+		q := req.URL.Query()
+		q.Add("audience", "api.nais.io")
 
-	q := req.URL.Query()
-	q.Add("audience", "api.nais.io")
+		req.URL.RawQuery = q.Encode()
+		req.Header.Set("Authorization", "bearer "+requestToken)
 
-	req.URL.RawQuery = q.Encode()
-	req.Header.Set("Authorization", "bearer "+g.requestToken)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("fetching token: %w", err)
+		}
+		defer resp.Body.Close()
 
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("fetching token: %w", err)
-	}
-	defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return nil, fmt.Errorf("unexpected status code: %s", resp.Status)
+		}
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("unexpected status code: %s", resp.Status)
-	}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("reading body: %w", err)
+		}
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading body: %w", err)
-	}
+		var tokenResponse struct {
+			Token string `json:"value"`
+		}
+		err = json.Unmarshal(body, &tokenResponse)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshalling json: %w", err)
+		}
 
-	var tokenResponse struct {
-		Token string `json:"value"`
-	}
-	err = json.Unmarshal(body, &tokenResponse)
-	if err != nil {
-		return nil, fmt.Errorf("unmarshalling json: %w", err)
-	}
+		// Skip signature verification here as we're only interested in the expiry time.
+		// The API will validate the token later.
+		j, err := jwt.ParseString(tokenResponse.Token,
+			jwt.WithVerify(false),
+			jwt.WithAcceptableSkew(10*time.Second),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("parse jwt: %w", err)
+		}
 
-	return &oauth2.Token{
-		AccessToken: tokenResponse.Token,
-	}, nil
+		expiry, ok := j.Expiration()
+		if !ok {
+			return nil, fmt.Errorf("missing expiry claim")
+		}
+
+		return &oauth2.Token{
+			AccessToken: tokenResponse.Token,
+			Expiry:      expiry,
+		}, nil
+	})
 }

--- a/internal/naisapi/auth/localhost.go
+++ b/internal/naisapi/auth/localhost.go
@@ -2,12 +2,15 @@ package auth
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"os"
 
 	"golang.org/x/oauth2"
 )
+
+type LocalhostUser struct {
+	AuthenticatedUser
+}
 
 func Localhost() (*LocalhostUser, bool) {
 	host := os.Getenv("NAIS_API_LOCAL_HOST")
@@ -16,51 +19,28 @@ func Localhost() (*LocalhostUser, bool) {
 	}
 
 	return &LocalhostUser{
-		consoleHost: host,
-		email:       os.Getenv("NAIS_API_LOCAL_EMAIL"),
+		AuthenticatedUser{
+			consoleHost: host,
+			domain:      "api.nais.localhost",
+			email:       os.Getenv("NAIS_API_LOCAL_EMAIL"),
+			ts: oauth2.StaticTokenSource(&oauth2.Token{
+				AccessToken: "not-really-an-access-token",
+			}),
+		},
 	}, true
 }
 
-type LocalhostUser struct {
-	consoleHost string
-	email       string
-}
-
-type LocalhostTokenSource struct{}
-
-func (l *LocalhostTokenSource) Token() (*oauth2.Token, error) {
-	return &oauth2.Token{
-		AccessToken: "not-really-an-access-token",
-	}, nil
-}
-
-func (l *LocalhostUser) Domain() string {
-	return "example.com"
-}
-
-func (l *LocalhostUser) Email() string {
-	return l.email
-}
-
-func (l *LocalhostUser) ConsoleHost() string {
-	return l.consoleHost
-}
-
-func (l *LocalhostUser) APIURL() string {
-	return fmt.Sprintf("http://%s/graphql", l.ConsoleHost())
-}
-
-func (l *LocalhostUser) HTTPClient(ctx context.Context) *http.Client {
+func (l *LocalhostUser) HTTPClient(_ context.Context) *http.Client {
 	return &http.Client{
 		Transport: l.RoundTripper(http.DefaultTransport),
 	}
 }
 
 func (l *LocalhostUser) RoundTripper(base http.RoundTripper) http.RoundTripper {
-	return &LocalhostRoundtripper{
-		user: l,
-		base: base,
-	}
+	return roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		_ = l.SetAuthorizationHeader(r.Header)
+		return base.RoundTrip(r)
+	})
 }
 
 func (l *LocalhostUser) SetAuthorizationHeader(headers http.Header) error {
@@ -68,18 +48,4 @@ func (l *LocalhostUser) SetAuthorizationHeader(headers http.Header) error {
 		headers.Set("X-User-Email", l.email)
 	}
 	return nil
-}
-
-func (l *LocalhostUser) GetTokenSource() oauth2.TokenSource {
-	return &LocalhostTokenSource{}
-}
-
-type LocalhostRoundtripper struct {
-	user *LocalhostUser
-	base http.RoundTripper
-}
-
-func (l *LocalhostRoundtripper) RoundTrip(r *http.Request) (*http.Response, error) {
-	_ = l.user.SetAuthorizationHeader(r.Header)
-	return l.base.RoundTrip(r)
 }

--- a/internal/postgres/postgresinfo.go
+++ b/internal/postgres/postgresinfo.go
@@ -39,7 +39,7 @@ func (p *postgresDBInfo) DBConnection(ctx context.Context) (*ConnectionInfo, err
 	if err != nil {
 		return nil, err
 	}
-	token, err := user.GetTokenSource().Token()
+	token, err := user.AccessToken()
 	if err != nil {
 		return nil, err
 	}
@@ -50,14 +50,14 @@ func (p *postgresDBInfo) DBConnection(ctx context.Context) (*ConnectionInfo, err
 	queries.Add("sslmode", "required")
 	pgUrl := &url.URL{
 		Scheme:   "postgresql",
-		User:     url.UserPassword(email, token.AccessToken),
+		User:     url.UserPassword(email, token),
 		Host:     "localhost",
 		Path:     "app",
 		RawQuery: queries.Encode(),
 	}
 
 	queries.Add("user", email)
-	queries.Add("password", token.AccessToken)
+	queries.Add("password", token)
 	jdbcUrl := &url.URL{
 		Scheme:   "jdbc:postgresql",
 		Host:     "localhost:5432",
@@ -68,7 +68,7 @@ func (p *postgresDBInfo) DBConnection(ctx context.Context) (*ConnectionInfo, err
 	return &ConnectionInfo{
 		username: email,
 		email:    email,
-		password: token.AccessToken,
+		password: token,
 		dbName:   "app",
 		instance: "localhost",
 		port:     "5432",


### PR DESCRIPTION
- Re-validate and fetch claims from id_token instead of storing and getting them from the keyring.
- Implement refresh of tokens for GitHub Actions users.