### PR TITLE
fix(grant_access): streamline access management

### DIFF
--- a/internal/aiven/command/flag/flag.go
+++ b/internal/aiven/command/flag/flag.go
@@ -24,15 +24,14 @@ type CreateOpenSearch struct {
 
 type GrantAccess struct {
 	*Aiven
+	Namespace string `name:"namespace" short:"n" usage:"|NAMESPACE| of the *.kafka.nais.io resource."`
 }
 
 type GrantAccessStream struct {
 	*GrantAccess
-	Namespace string `name:"namespace" short:"n" usage:"|NAMESPACE| of the stream.kafka.nais.io resource."`
 }
 
 type GrantAccessTopic struct {
 	*GrantAccess
-	Access    string `name:"access" short:"a" usage:"Access |LEVEL| (readwrite, read and write)."`
-	Namespace string `name:"namespace" short:"n" usage:"|NAMESPACE| of the topic.kafka.nais.io resource."`
+	Access string `name:"access" short:"a" usage:"Access |LEVEL| (readwrite, read and write)."`
 }

--- a/internal/aiven/command/grant_access_stream.go
+++ b/internal/aiven/command/grant_access_stream.go
@@ -38,7 +38,7 @@ func grantAccessStream(parentFlags *flag.GrantAccess) *naistrix.Command {
 			}
 
 			if accessResult.AlreadyAdded {
-				out.Printf("Username '%s' already listed in Stream '%s/%s' ACLs.", userName, namespace, stream)
+				out.Printf("Username '%s' already exists in Stream '%s/%s' ACLs.", userName, namespace, stream)
 				return nil
 			}
 

--- a/internal/aiven/command/grant_access_topic.go
+++ b/internal/aiven/command/grant_access_topic.go
@@ -34,6 +34,10 @@ func grantAccessTopic(parentFlags *flag.GrantAccess) *naistrix.Command {
 			topicName := args.Get("topic")
 			username := args.Get("username")
 
+			if err := aiven.ValidAclPermission(access); err != nil {
+				return err
+			}
+
 			newAcl := nais_kafka.TopicACL{
 				Team:        namespace,
 				Application: username,
@@ -45,14 +49,14 @@ func grantAccessTopic(parentFlags *flag.GrantAccess) *naistrix.Command {
 			}
 
 			if accessResult.AlreadyAdded {
-				out.Printf("An ACL already exists for user/access '%s' on topic '%s/%s'.",
+				out.Printf("ACL entry already exists for '%s/%s' on topic %s/%s.",
 					newAcl.Application, newAcl.Access, namespace, topicName,
 				)
 				return nil
 			}
 
-			out.Printf("ACL added for team '%s', application '%s', access '%s' on topic '%s/%s'.",
-				newAcl.Team, newAcl.Application, newAcl.Access, namespace, topicName,
+			out.Printf("ACL added for '%s', with access '%s' on topic '%s/%s'.",
+				newAcl.Application, newAcl.Access, namespace, topicName,
 			)
 			return nil
 		},

--- a/internal/aiven/grant_access.go
+++ b/internal/aiven/grant_access.go
@@ -11,8 +11,6 @@ import (
 
 type GrantAccessResult struct {
 	AlreadyAdded bool
-	Namespace    string
-	Name         string
 }
 
 func GrantAccessToTopic(ctx context.Context, namespace, topicName string, newAcl nais_kafka.TopicACL) (*GrantAccessResult, error) {
@@ -30,8 +28,6 @@ func GrantAccessToTopic(ctx context.Context, namespace, topicName string, newAcl
 	if checkIfAclInList(topic.Spec.ACL, newAcl) {
 		return &GrantAccessResult{
 			AlreadyAdded: true,
-			Namespace:    namespace,
-			Name:         topicName,
 		}, nil
 	}
 	topic.Spec.ACL = append(topic.Spec.ACL, newAcl)
@@ -42,8 +38,6 @@ func GrantAccessToTopic(ctx context.Context, namespace, topicName string, newAcl
 
 	return &GrantAccessResult{
 		AlreadyAdded: false,
-		Namespace:    namespace,
-		Name:         topicName,
 	}, nil
 }
 
@@ -62,8 +56,6 @@ func GrantAccessToStream(ctx context.Context, namespace, streamName, userName st
 	if checkIfUserInList(stream.Spec.AdditionalUsers, userName) {
 		return &GrantAccessResult{
 			AlreadyAdded: true,
-			Namespace:    namespace,
-			Name:         streamName,
 		}, nil
 	}
 	stream.Spec.AdditionalUsers = append(stream.Spec.AdditionalUsers, nais_kafka.AdditionalStreamUser{Username: userName})
@@ -74,8 +66,6 @@ func GrantAccessToStream(ctx context.Context, namespace, streamName, userName st
 
 	return &GrantAccessResult{
 		AlreadyAdded: false,
-		Namespace:    namespace,
-		Name:         streamName,
 	}, nil
 }
 
@@ -95,4 +85,13 @@ func checkIfUserInList(existing []nais_kafka.AdditionalStreamUser, userName stri
 		}
 	}
 	return false
+}
+
+func ValidAclPermission(access string) error {
+	switch access {
+	case "read", "write", "readwrite":
+		return nil
+	default:
+		return fmt.Errorf("invalid access type: %s (valid: read, write, readwrite)", access)
+	}
 }


### PR DESCRIPTION
Improving the handling and validation of access grants for Kafka topics and streams. 

The main changes include refactoring flag definitions for namespaces, improving user feedback messages, adding validation for ACL permissions, and simplifying the `GrantAccessResult` structure.