### PR TITLE
fix: remove duplicate -t flag shorthands that conflict with global --team flag

### DIFF
--- a/internal/aiven/command/flag/flag.go
+++ b/internal/aiven/command/flag/flag.go
@@ -19,7 +19,7 @@ type Create struct {
 
 type CreateKafka struct {
 	*Create
-	Test int    `name:"test" short:"t" usage:"Create a test Kafka topic with the given |NAME|."`
+	Test int    `name:"test" usage:"Create a test Kafka topic with the given |NAME|."`
 	Pool string `name:"pool" short:"p" usage:"The |NAME| of the pool to create the Kafka instance in."`
 }
 

--- a/internal/log/command/flag/flag.go
+++ b/internal/log/command/flag/flag.go
@@ -10,7 +10,7 @@ type LogFlags struct {
 	*flag.Alpha
 
 	Environment    string        `name:"environment" short:"e" usage:"Filter logs to a specific |environment|."`
-	Team           []string      `name:"team" short:"t" usage:"Filter logs to a single |team|. Can be repeated."`
+	Team           []string      `name:"team" usage:"Filter logs to a single |team|. Can be repeated."`
 	Workload       []string      `name:"workload" short:"w" usage:"Filter logs to a single |workload|. Can be repeated."`
 	Container      []string      `name:"container" short:"c" usage:"Filter logs to a specific |container|. Can be repeated."`
 	WithTimestamps bool          `name:"with-timestamps" usage:"Include timestamps in log output."`

--- a/internal/opensearch/command/flag/flag.go
+++ b/internal/opensearch/command/flag/flag.go
@@ -25,7 +25,7 @@ func (e *Env) AutoComplete(ctx context.Context, args *naistrix.Arguments, str st
 type Create struct {
 	*OpenSearch
 	Memory    Memory  `name:"memory" short:"m" usage:"|MEMORY| of the OpenSearch instance. Defaults to |GB_4|."`
-	Tier      Tier    `name:"tier" short:"t" usage:"|TIER| of the OpenSearch instance. Defaults to |SINGLE_NODE|."`
+	Tier      Tier    `name:"tier" usage:"|TIER| of the OpenSearch instance. Defaults to |SINGLE_NODE|."`
 	Version   Version `name:"version" usage:"Major |VERSION| of the OpenSearch instance. Defaults to |V2|."`
 	StorageGB int     `name:"storage-gb" usage:"Storage capacity in |GB| for the OpenSearch instance. Defaults vary for different combinations of |TIER| and |MEMORY|."`
 }
@@ -92,7 +92,7 @@ func (o *Output) AutoComplete(context.Context, *naistrix.Arguments, string, any)
 type Update struct {
 	*OpenSearch
 	Memory       Memory  `name:"memory" short:"m" usage:"|MEMORY| of the OpenSearch instance."`
-	Tier         Tier    `name:"tier" short:"t" usage:"|TIER| of the OpenSearch instance."`
+	Tier         Tier    `name:"tier" usage:"|TIER| of the OpenSearch instance."`
 	MajorVersion Version `name:"version" usage:"Major |VERSION| of the OpenSearch instance."`
 	StorageGB    int     `name:"storage-gb" usage:"Storage capacity in |GB| for the OpenSearch instance. Defaults vary for different combinations of |TIER| and |MEMORY|."`
 }

--- a/internal/valkey/command/flag/flag.go
+++ b/internal/valkey/command/flag/flag.go
@@ -33,7 +33,7 @@ type Create struct {
 	*Valkey
 	Yes             bool            `name:"yes" short:"y" usage:"Automatic yes to prompts; assume 'yes' as answer to all prompts and run non-interactively."`
 	Memory          Memory          `name:"memory" short:"m" usage:"|MEMORY| of the Valkey instance. Defaults to |GB_1|."`
-	Tier            Tier            `name:"tier" short:"t" usage:"|TIER| of the Valkey instance. Defaults to |HIGH_AVAILABILITY|."`
+	Tier            Tier            `name:"tier" usage:"|TIER| of the Valkey instance. Defaults to |HIGH_AVAILABILITY|."`
 	MaxMemoryPolicy MaxMemoryPolicy `name:"max-memory-policy" usage:"|MAX_MEMORY_POLICY| for the Valkey instance. Defaults to |NO_EVICTION|."`
 }
 
@@ -82,7 +82,7 @@ type Update struct {
 	*Valkey
 	Yes             bool            `name:"yes" short:"y" usage:"Automatic yes to prompts; assume 'yes' as answer to all prompts and run non-interactively."`
 	Memory          Memory          `name:"memory" short:"m" usage:"|MEMORY| of the Valkey instance."`
-	Tier            Tier            `name:"tier" short:"t" usage:"|TIER| of the Valkey instance."`
+	Tier            Tier            `name:"tier" usage:"|TIER| of the Valkey instance."`
 	MaxMemoryPolicy MaxMemoryPolicy `name:"max-memory-policy" usage:"|MAX_MEMORY_POLICY| for the Valkey instance."`
 }
 


### PR DESCRIPTION
## Summary

- Removes `short:"t"` from local flags that conflict with the inherited global `--team` (`-t`) flag, which caused runtime panics
- Affected commands: `aiven create kafka` (`--test`), `valkey create/update` (`--tier`), `opensearch create/update` (`--tier`), `log` (`--team` as `[]string`)

## Root cause

Flag structs embed `GlobalFlags` (which defines `--team` with `short:"t"`), and several child structs also defined their own flags with `short:"t"`. When both shorthands are registered on the same cobra flagset, it panics:

```
panic: unable to redefine 't' shorthand in "kafka" flagset: it's already used for "test" flag
```

## Changes

| File | Flag | Change |
|------|------|--------|
| `internal/aiven/command/flag/flag.go` | `--test` on `CreateKafka` | Removed `short:"t"` |
| `internal/valkey/command/flag/flag.go` | `--tier` on `Create` | Removed `short:"t"` |
| `internal/valkey/command/flag/flag.go` | `--tier` on `Update` | Removed `short:"t"` |
| `internal/opensearch/command/flag/flag.go` | `--tier` on `Create` | Removed `short:"t"` |
| `internal/opensearch/command/flag/flag.go` | `--tier` on `Update` | Removed `short:"t"` |
| `internal/log/command/flag/flag.go` | `--team` on `LogFlags` | Removed `short:"t"` |

These flags remain fully usable via their long names (`--test`, `--tier`, `--team`).