### PR TITLE
test: set Commands for test

### DIFF
--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -84,7 +84,7 @@ func newApplication(w io.Writer) (*Application, *flags.GlobalFlags, error) {
 		return nil, nil, err
 	}
 
-	return &Application{Application: app}, globalFlags, nil
+	return &Application{Application: app, Commands: cmds}, globalFlags, nil
 }
 
 func Run(ctx context.Context, w io.Writer) error {


### PR DESCRIPTION
It seems that the test that executes all commands with the --help option has been broken for a while.