### PR TITLE
fix(postgres): use API-fetched secret values instead of reading K8s secrets directly

### DIFF
--- a/internal/postgres/access.go
+++ b/internal/postgres/access.go
@@ -36,7 +36,8 @@ var (
 
 func PrepareAccess(ctx context.Context, appName string, fl *flag.Prepare, out *naistrix.OutputWriter) error {
 	// Get secret values (access is logged for audit purposes)
-	if _, err := GetSecretValues(ctx, appName, fl.Postgres, ReasonPrepareAccess, out); err != nil {
+	sv, err := GetSecretValues(ctx, appName, fl.Postgres, ReasonPrepareAccess, out)
+	if err != nil {
 		return err
 	}
 
@@ -48,15 +49,16 @@ func PrepareAccess(ctx context.Context, appName string, fl *flag.Prepare, out *n
 	}
 
 	if fl.AllPrivileges {
-		return sqlExecAsAppUser(ctx, appName, fl.Team, fl.Environment, fl.Schema, prependUsageIfNotPublic(grantAllPrivs))
+		return sqlExecAsAppUser(ctx, appName, fl.Team, fl.Environment, fl.Schema, prependUsageIfNotPublic(grantAllPrivs), sv)
 	} else {
-		return sqlExecAsAppUser(ctx, appName, fl.Team, fl.Environment, fl.Schema, prependUsageIfNotPublic(grantSelectPrivs))
+		return sqlExecAsAppUser(ctx, appName, fl.Team, fl.Environment, fl.Schema, prependUsageIfNotPublic(grantSelectPrivs), sv)
 	}
 }
 
 func RevokeAccess(ctx context.Context, appName string, fl *flag.Revoke, out *naistrix.OutputWriter) error {
 	// Get secret values (access is logged for audit purposes)
-	if _, err := GetSecretValues(ctx, appName, fl.Postgres, ReasonRevokeAccess, out); err != nil {
+	sv, err := GetSecretValues(ctx, appName, fl.Postgres, ReasonRevokeAccess, out)
+	if err != nil {
 		return err
 	}
 
@@ -64,14 +66,16 @@ func RevokeAccess(ctx context.Context, appName string, fl *flag.Revoke, out *nai
 	if fl.Schema != "public" {
 		q += "\n" + revokeUsage
 	}
-	return sqlExecAsAppUser(ctx, appName, fl.Team, fl.Environment, fl.Schema, q)
+	return sqlExecAsAppUser(ctx, appName, fl.Team, fl.Environment, fl.Schema, q, sv)
 }
 
-func sqlExecAsAppUser(ctx context.Context, appName string, namespace string, cluster flag.Environment, schema, statement string) error {
+func sqlExecAsAppUser(ctx context.Context, appName string, namespace string, cluster flag.Environment, schema, statement string, sv *SecretValues) error {
 	dbInfo, err := NewDBInfo(ctx, appName, namespace, cluster)
 	if err != nil {
 		return err
 	}
+
+	dbInfo.SetSecretValues(sv)
 
 	connectionInfo, err := dbInfo.DBConnection(ctx)
 	if err != nil {

--- a/internal/postgres/audit.go
+++ b/internal/postgres/audit.go
@@ -14,26 +14,30 @@ import (
 
 func EnableAuditLogging(ctx context.Context, appName string, fl *flag.EnableAudit, out *naistrix.OutputWriter) error {
 	// Get secret values (access is logged for audit purposes)
-	if _, err := GetSecretValues(ctx, appName, fl.Postgres, ReasonEnableAudit, out); err != nil {
+	sv, err := GetSecretValues(ctx, appName, fl.Postgres, ReasonEnableAudit, out)
+	if err != nil {
 		return err
 	}
-	return enableAuditAsAppUser(ctx, appName, fl.Team, fl.Environment, out)
+	return enableAuditAsAppUser(ctx, appName, fl.Team, fl.Environment, sv, out)
 }
 
 func VerifyAuditLogging(ctx context.Context, appName string, fl *flag.VerifyAudit, out *naistrix.OutputWriter) error {
 	// Get secret values (access is logged for audit purposes)
-	if _, err := GetSecretValues(ctx, appName, fl.Postgres, ReasonVerifyAudit, out); err != nil {
+	sv, err := GetSecretValues(ctx, appName, fl.Postgres, ReasonVerifyAudit, out)
+	if err != nil {
 		return err
 	}
-	_, err := verifyAuditAsAppUser(ctx, appName, fl.Team, fl.Environment, out)
+	_, err = verifyAuditAsAppUser(ctx, appName, fl.Team, fl.Environment, sv, out)
 	return err
 }
 
-func enableAuditAsAppUser(ctx context.Context, appName string, namespace string, cluster flag.Environment, out *naistrix.OutputWriter) error {
+func enableAuditAsAppUser(ctx context.Context, appName string, namespace string, cluster flag.Environment, sv *SecretValues, out *naistrix.OutputWriter) error {
 	dbInfo, err := NewDBInfo(ctx, appName, namespace, cluster)
 	if err != nil {
 		return err
 	}
+
+	dbInfo.SetSecretValues(sv)
 
 	connectionInfo, err := dbInfo.DBConnection(ctx)
 	if err != nil {
@@ -197,11 +201,13 @@ func getDBFlags(ctx context.Context, info *CloudSQLDBInfo) (map[string]string, e
 	return dbFlags, nil
 }
 
-func verifyAuditAsAppUser(ctx context.Context, appName string, namespace string, cluster flag.Environment, out *naistrix.OutputWriter) (bool, error) {
+func verifyAuditAsAppUser(ctx context.Context, appName string, namespace string, cluster flag.Environment, sv *SecretValues, out *naistrix.OutputWriter) (bool, error) {
 	dbInfo, err := NewDBInfo(ctx, appName, namespace, cluster)
 	if err != nil {
 		return false, err
 	}
+
+	dbInfo.SetSecretValues(sv)
 
 	connectionInfo, err := dbInfo.DBConnection(ctx)
 	if err != nil {

--- a/internal/postgres/cloudsqldbinfo.go
+++ b/internal/postgres/cloudsqldbinfo.go
@@ -26,10 +26,15 @@ type CloudSQLDBInfo struct {
 	*DBInfo
 	projectID      string
 	connectionName string
+	secretValues   *SecretValues
 }
 
 func (i *CloudSQLDBInfo) ToCloudSQLDBInfo() (*CloudSQLDBInfo, error) {
 	return i, nil
+}
+
+func (i *CloudSQLDBInfo) SetSecretValues(sv *SecretValues) {
+	i.secretValues = sv
 }
 
 func (i *CloudSQLDBInfo) ProjectID(ctx context.Context) (string, error) {
@@ -53,9 +58,8 @@ func (i *CloudSQLDBInfo) ConnectionName(ctx context.Context) (string, error) {
 }
 
 func (i *CloudSQLDBInfo) DBConnection(ctx context.Context) (*ConnectionInfo, error) {
-	secret, err := i.k8sClient.CoreV1().Secrets(string(i.namespace)).Get(ctx, "google-sql-"+i.appName, meta_v1.GetOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("unable to get database password from %q in %q: %w", "google-sql-"+i.appName, i.namespace, err)
+	if i.secretValues == nil {
+		return nil, fmt.Errorf("secret values not set for %q; call SetSecretValues before DBConnection", i.appName)
 	}
 
 	connectionName, err := i.ConnectionName(ctx)
@@ -63,7 +67,41 @@ func (i *CloudSQLDBInfo) DBConnection(ctx context.Context) (*ConnectionInfo, err
 		return nil, err
 	}
 
-	return createConnectionInfo(ctx, *secret, connectionName)
+	return createConnectionInfoFromSecretValues(ctx, i.secretValues, connectionName)
+}
+
+func createConnectionInfoFromSecretValues(ctx context.Context, sv *SecretValues, instance string) (*ConnectionInfo, error) {
+	var pgUrl *url.URL
+	var jdbcUrl *url.URL
+	for name, val := range sv.values {
+		if strings.HasSuffix(name, "_URL") {
+			u, err := url.Parse(val)
+			if err != nil {
+				continue
+			}
+			if strings.HasSuffix(name, "_JDBC_URL") {
+				jdbcUrl = u
+			} else {
+				pgUrl = u
+			}
+		}
+	}
+
+	email, err := currentEmail(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ConnectionInfo{
+		username: sv.Get("_USERNAME"),
+		email:    email,
+		password: sv.Get("_PASSWORD"),
+		dbName:   sv.Get("_DATABASE"),
+		port:     sv.Get("_PORT"),
+		url:      pgUrl,
+		jdbcUrl:  jdbcUrl,
+		instance: instance,
+	}, nil
 }
 
 func createConnectionInfo(ctx context.Context, secret core_v1.Secret, instance string) (*ConnectionInfo, error) {

--- a/internal/postgres/dbinfo.go
+++ b/internal/postgres/dbinfo.go
@@ -21,6 +21,7 @@ type DB interface {
 	RunProxy(ctx context.Context, host string, port *uint, portCh chan<- int, out *naistrix.OutputWriter, printInstructions bool) error
 
 	AppName() string
+	SetSecretValues(sv *SecretValues)
 
 	// TODO: Remove when interface migration complete
 	ToCloudSQLDBInfo() (*CloudSQLDBInfo, error)

--- a/internal/postgres/iam.go
+++ b/internal/postgres/iam.go
@@ -213,7 +213,8 @@ func formatCondition(expr, title string) string {
 
 func ListUsers(ctx context.Context, appName string, fl *flag.UserList, out *naistrix.OutputWriter) error {
 	// Get secret values (access is logged for audit purposes)
-	if _, err := GetSecretValues(ctx, appName, fl.Postgres, ReasonListUsers, out); err != nil {
+	sv, err := GetSecretValues(ctx, appName, fl.Postgres, ReasonListUsers, out)
+	if err != nil {
 		return err
 	}
 
@@ -221,6 +222,8 @@ func ListUsers(ctx context.Context, appName string, fl *flag.UserList, out *nais
 	if err != nil {
 		return err
 	}
+
+	dbInfo.SetSecretValues(sv)
 
 	connectionInfo, err := dbInfo.DBConnection(ctx)
 	if err != nil {
@@ -262,7 +265,8 @@ func AddUser(ctx context.Context, appName, username, password string, fl *flag.U
 	}
 
 	// Get secret values (access is logged for audit purposes)
-	if _, err := GetSecretValues(ctx, appName, fl.Postgres, ReasonAddUser, out); err != nil {
+	sv, err := GetSecretValues(ctx, appName, fl.Postgres, ReasonAddUser, out)
+	if err != nil {
 		return err
 	}
 
@@ -270,6 +274,8 @@ func AddUser(ctx context.Context, appName, username, password string, fl *flag.U
 	if err != nil {
 		return err
 	}
+
+	dbInfo.SetSecretValues(sv)
 
 	connectionInfo, err := dbInfo.DBConnection(ctx)
 	if err != nil {
@@ -302,7 +308,8 @@ func AddUser(ctx context.Context, appName, username, password string, fl *flag.U
 
 func DropUser(ctx context.Context, appName string, username string, fl *flag.UserDrop, out *naistrix.OutputWriter) error {
 	// Get secret values (access is logged for audit purposes)
-	if _, err := GetSecretValues(ctx, appName, fl.Postgres, ReasonDropUser, out); err != nil {
+	sv, err := GetSecretValues(ctx, appName, fl.Postgres, ReasonDropUser, out)
+	if err != nil {
 		return err
 	}
 
@@ -310,6 +317,8 @@ func DropUser(ctx context.Context, appName string, username string, fl *flag.Use
 	if err != nil {
 		return err
 	}
+
+	dbInfo.SetSecretValues(sv)
 
 	connectionInfo, err := dbInfo.DBConnection(ctx)
 	if err != nil {

--- a/internal/postgres/password.go
+++ b/internal/postgres/password.go
@@ -19,7 +19,8 @@ import (
 
 func RotatePassword(ctx context.Context, appName string, fl *flag.Password, out *naistrix.OutputWriter) error {
 	// Get secret values (access is logged for audit purposes)
-	if _, err := GetSecretValues(ctx, appName, fl.Postgres, ReasonPasswordRotate, out); err != nil {
+	sv, err := GetSecretValues(ctx, appName, fl.Postgres, ReasonPasswordRotate, out)
+	if err != nil {
 		return err
 	}
 
@@ -27,6 +28,8 @@ func RotatePassword(ctx context.Context, appName string, fl *flag.Password, out 
 	if err != nil {
 		return err
 	}
+
+	dbInfo.SetSecretValues(sv)
 
 	cloudSQLDBInfo, err := dbInfo.ToCloudSQLDBInfo()
 	if err != nil {

--- a/internal/postgres/postgresinfo.go
+++ b/internal/postgres/postgresinfo.go
@@ -184,6 +184,10 @@ func (p *postgresDBInfo) ToCloudSQLDBInfo() (*CloudSQLDBInfo, error) {
 	return nil, fmt.Errorf("not a CloudSQL instance")
 }
 
+func (p *postgresDBInfo) SetSecretValues(_ *SecretValues) {
+	// No-op for in-cluster postgres; authentication uses OAuth tokens
+}
+
 func (p *postgresDBInfo) fetchClusterInfo(ctx context.Context) error {
 	unstructuredApp, err := p.dynamicClient.Resource(schema.GroupVersionResource{
 		Group:    "nais.io",

--- a/internal/postgres/proxy.go
+++ b/internal/postgres/proxy.go
@@ -13,7 +13,8 @@ import (
 
 func RunProxy(ctx context.Context, appName string, fl *flag.Proxy, out *naistrix.OutputWriter) error {
 	// Get secret values with user-provided reason (access is logged for audit purposes)
-	if _, err := GetSecretValuesWithUserReason(ctx, appName, fl.Postgres, fl.Reason, out); err != nil {
+	sv, err := GetSecretValuesWithUserReason(ctx, appName, fl.Postgres, fl.Reason, out)
+	if err != nil {
 		return err
 	}
 
@@ -21,6 +22,8 @@ func RunProxy(ctx context.Context, appName string, fl *flag.Proxy, out *naistrix
 	if err != nil {
 		return err
 	}
+
+	dbInfo.SetSecretValues(sv)
 
 	return dbInfo.RunProxy(ctx, fl.Host, &fl.Port, make(chan<- int, 1), out, true)
 }

--- a/internal/postgres/psql.go
+++ b/internal/postgres/psql.go
@@ -13,7 +13,8 @@ import (
 
 func RunPSQL(ctx context.Context, appName string, fl *flag.Psql, out *naistrix.OutputWriter) error {
 	// Get secret values with user-provided reason (access is logged for audit purposes)
-	if _, err := GetSecretValuesWithUserReason(ctx, appName, fl.Postgres, fl.Reason, out); err != nil {
+	sv, err := GetSecretValuesWithUserReason(ctx, appName, fl.Postgres, fl.Reason, out)
+	if err != nil {
 		return err
 	}
 
@@ -26,6 +27,8 @@ func RunPSQL(ctx context.Context, appName string, fl *flag.Psql, out *naistrix.O
 	if err != nil {
 		return err
 	}
+
+	dbInfo.SetSecretValues(sv)
 
 	connectionInfo, err := dbInfo.DBConnection(ctx)
 	if err != nil {

--- a/internal/postgres/secret.go
+++ b/internal/postgres/secret.go
@@ -35,6 +35,17 @@ type SecretValues struct {
 	values map[string]string
 }
 
+// Get returns the value for a key with the given suffix (e.g. "_PASSWORD", "_USERNAME").
+// Keys are matched by suffix to handle prefixed key names like "NAIS_DATABASE_MYAPP_PASSWORD".
+func (s *SecretValues) Get(suffix string) string {
+	for name, val := range s.values {
+		if strings.HasSuffix(name, suffix) {
+			return val
+		}
+	}
+	return ""
+}
+
 // GetSecretValues retrieves the values of a database secret via the API.
 // For CloudSQL databases, this retrieves the secret values directly.
 // For in-cluster postgres, this grants temporary access to the database.


### PR DESCRIPTION
## Summary

- **Fix CloudSQL postgres commands failing** for users without direct Kubernetes secret read permissions (e.g. `nais postgres proxy`, `psql`, `password rotate`, IAM, audit, access commands)
- **Root cause**: `CloudSQLDBInfo.DBConnection()` read secrets from Kubernetes directly, even though the CLI already fetched them via the Nais GraphQL API (`ViewSecretValues` mutation). Users without K8s secret RBAC got: `secrets "google-sql-<app>" is forbidden: User "<email>" cannot get resource "secrets"`
- **Fix**: Pass the already-fetched `SecretValues` through to `CloudSQLDBInfo` via a new `SetSecretValues()` method on the `DB` interface, and build `ConnectionInfo` from those values instead of making a redundant (and forbidden) K8s secret read

## Changes

- Added `SetSecretValues(*SecretValues)` to the `DB` interface (`dbinfo.go`)
- Added `secretValues` field and `SetSecretValues` implementation to `CloudSQLDBInfo`
- Rewrote `CloudSQLDBInfo.DBConnection()` to use stored secret values instead of K8s secret read
- Added `createConnectionInfoFromSecretValues()` helper that builds `ConnectionInfo` from API-fetched values
- Added `SecretValues.Get(suffix)` method for suffix-based key lookup (handles prefixed keys like `NAIS_DATABASE_MYAPP_PASSWORD`)
- Added no-op `SetSecretValues` to `postgresDBInfo` (in-cluster postgres uses OAuth tokens, not secrets)
- Updated all callers: `proxy.go`, `psql.go`, `password.go`, `iam.go`, `audit.go`, `access.go`
- Old `createConnectionInfo()` retained for use in `password_test.go` and K8s secret writes during password rotation

## Testing

- All existing tests pass (`mise run test`)
- Static analysis clean (`staticcheck`, `govet`, `deadcode`, `govulncheck`)
- Build compiles cleanly