### PR TITLE
fix: update stale references from `nais config set team` to `nais defaults set team`

### DIFF
--- a/internal/app/command/activity.go
+++ b/internal/app/command/activity.go
@@ -55,7 +55,7 @@ func activity(parentFlags *flag.App) *naistrix.Command {
 		AutoCompleteFunc: func(ctx context.Context, args *naistrix.Arguments, _ string) ([]string, string) {
 			if args.Len() == 0 {
 				if len(flags.Team) == 0 {
-					return nil, "Please provide team to auto-complete application names. 'nais config set team <team>', or '--team <team>' flag."
+					return nil, "Please provide team to auto-complete application names. 'nais defaults set team <team>', or '--team <team>' flag."
 				}
 				environments := []string(flags.Environment)
 				if len(environments) == 0 {

--- a/internal/app/command/flag/flag.go
+++ b/internal/app/command/flag/flag.go
@@ -40,7 +40,7 @@ func (i *instances) AutoComplete(ctx context.Context, args *naistrix.Arguments, 
 	}
 
 	if len(f.Team) == 0 {
-		return nil, "Please provide team to auto-complete instances. 'nais config team set <team>', or '--team <team>' flag."
+		return nil, "Please provide team to auto-complete instances. 'nais defaults set team <team>', or '--team <team>' flag."
 	}
 
 	instances, err := app.GetApplicationInstances(ctx, string(f.Team), args.Get("name"), string(f.Environment))
@@ -93,7 +93,7 @@ func (e *Env) AutoComplete(ctx context.Context, args *naistrix.Arguments, str st
 
 	f := flags.(*Log)
 	if len(f.Team) == 0 {
-		return nil, "Please provide team to auto-complete environments. 'nais config team set <team>', or '--team <team>' flag."
+		return nil, "Please provide team to auto-complete environments. 'nais defaults set team <team>', or '--team <team>' flag."
 	}
 
 	envs, err := app.ApplicationEnvironments(ctx, f.Team, args.Get("name"))

--- a/internal/app/command/issues.go
+++ b/internal/app/command/issues.go
@@ -41,7 +41,7 @@ func issues(parentFlags *flag.App) *naistrix.Command {
 		AutoCompleteFunc: func(ctx context.Context, args *naistrix.Arguments, _ string) ([]string, string) {
 			if args.Len() == 0 {
 				if len(flags.Team) == 0 {
-					return nil, "Please provide team to auto-complete application names. 'nais config set team <team>', or '--team <team>' flag."
+					return nil, "Please provide team to auto-complete application names. 'nais defaults set team <team>', or '--team <team>' flag."
 				}
 				apps, err := app.GetApplicationNames(ctx, flags.Team, flags.Environment)
 				if err != nil {

--- a/internal/app/command/list.go
+++ b/internal/app/command/list.go
@@ -25,7 +25,7 @@ func list(parentFlags *flag.App) *naistrix.Command {
 		AutoCompleteFunc: func(_ context.Context, args *naistrix.Arguments, _ string) ([]string, string) {
 			if args.Len() == 0 {
 				if flags.Team == "" {
-					return nil, "Please provide team. 'nais config set team <team>', or '--team <team>' flag."
+					return nil, "Please provide team. 'nais defaults set team <team>', or '--team <team>' flag."
 				}
 			}
 			return nil, ""

--- a/internal/app/command/log.go
+++ b/internal/app/command/log.go
@@ -69,7 +69,7 @@ func log(parentFlags *flag.App) *naistrix.Command {
 		AutoCompleteFunc: func(ctx context.Context, args *naistrix.Arguments, _ string) ([]string, string) {
 			if args.Len() == 0 {
 				if len(flags.Team) == 0 {
-					return nil, "Please provide team to auto-complete application names. 'nais config set team <team>', or '--team <team>' flag."
+					return nil, "Please provide team to auto-complete application names. 'nais defaults set team <team>', or '--team <team>' flag."
 				}
 				if flags.Environment == "" {
 					return nil, "Please provide environment to auto-complete application names. '-e, --environment <environment>' flag."

--- a/internal/job/command/activity.go
+++ b/internal/job/command/activity.go
@@ -45,7 +45,7 @@ func activity(parentFlags *flag.Job) *naistrix.Command {
 		AutoCompleteFunc: func(ctx context.Context, args *naistrix.Arguments, _ string) ([]string, string) {
 			if args.Len() == 0 {
 				if len(flags.Team) == 0 {
-					return nil, "Please provide team to auto-complete job names. 'nais config set team <team>', or '--team <team>' flag."
+					return nil, "Please provide team to auto-complete job names. 'nais defaults set team <team>', or '--team <team>' flag."
 				}
 				environments := []string(flags.Environment)
 				if len(environments) == 0 {

--- a/internal/job/command/issues.go
+++ b/internal/job/command/issues.go
@@ -39,7 +39,7 @@ func issues(parentFlags *flag.Job) *naistrix.Command {
 		AutoCompleteFunc: func(ctx context.Context, args *naistrix.Arguments, _ string) ([]string, string) {
 			if args.Len() == 0 {
 				if len(flags.Team) == 0 {
-					return nil, "Please provide team to auto-complete job names. 'nais config set team <team>', or '--team <team>' flag."
+					return nil, "Please provide team to auto-complete job names. 'nais defaults set team <team>', or '--team <team>' flag."
 				}
 				jobs, err := job.GetJobNames(ctx, flags.Team, flags.Environment)
 				if err != nil {

--- a/internal/job/command/list.go
+++ b/internal/job/command/list.go
@@ -22,7 +22,7 @@ func list(parentFlags *flag.Job) *naistrix.Command {
 		AutoCompleteFunc: func(_ context.Context, args *naistrix.Arguments, _ string) ([]string, string) {
 			if args.Len() == 0 {
 				if flags.Team == "" {
-					return nil, "Please provide team. 'nais config set team <team>', or '--team <team>' flag."
+					return nil, "Please provide team. 'nais defaults set team <team>', or '--team <team>' flag."
 				}
 			}
 			return nil, ""

--- a/internal/job/command/log.go
+++ b/internal/job/command/log.go
@@ -97,7 +97,7 @@ func log(parentFlags *flag.Job) *naistrix.Command {
 		AutoCompleteFunc: func(ctx context.Context, args *naistrix.Arguments, _ string) ([]string, string) {
 			if args.Len() == 0 {
 				if len(flags.Team) == 0 {
-					return nil, "Please provide team to auto-complete job names. 'nais config set team <team>', or '--team <team>' flag."
+					return nil, "Please provide team to auto-complete job names. 'nais defaults set team <team>', or '--team <team>' flag."
 				}
 				if flags.Environment == "" {
 					return nil, "Please provide environment to auto-complete job names. '-e, --environment <environment>' flag."

--- a/internal/job/command/run_delete.go
+++ b/internal/job/command/run_delete.go
@@ -24,7 +24,7 @@ func deleteRun(parentFlags *flag.Job) *naistrix.Command {
 		AutoCompleteFunc: func(ctx context.Context, args *naistrix.Arguments, _ string) ([]string, string) {
 			if args.Len() == 0 {
 				if flags.Team == "" {
-					return nil, "Please provide team to auto-complete run names. 'nais config set team <team>', or '--team <team>' flag."
+					return nil, "Please provide team to auto-complete run names. 'nais defaults set team <team>', or '--team <team>' flag."
 				}
 				if flags.Environment == "" {
 					return []string{"--environment"}, ""

--- a/internal/job/command/run_list.go
+++ b/internal/job/command/run_list.go
@@ -24,7 +24,7 @@ func listRuns(parentFlags *flag.Job) *naistrix.Command {
 		AutoCompleteFunc: func(ctx context.Context, args *naistrix.Arguments, _ string) ([]string, string) {
 			if args.Len() == 0 {
 				if flags.Team == "" {
-					return nil, "Please provide team to auto-complete job names. 'nais config set team <team>', or '--team <team>' flag."
+					return nil, "Please provide team to auto-complete job names. 'nais defaults set team <team>', or '--team <team>' flag."
 				}
 				if flags.Environment == "" {
 					return []string{"--environment"}, ""

--- a/internal/job/command/trigger.go
+++ b/internal/job/command/trigger.go
@@ -38,7 +38,7 @@ func trigger(parentFlags *flag.Job) *naistrix.Command {
 		AutoCompleteFunc: func(ctx context.Context, args *naistrix.Arguments, _ string) ([]string, string) {
 			if args.Len() == 0 {
 				if len(flags.Team) == 0 {
-					return nil, "Please provide team to auto-complete job names. 'nais config set team <team>', or '--team <team>' flag."
+					return nil, "Please provide team to auto-complete job names. 'nais defaults set team <team>', or '--team <team>' flag."
 				}
 				if flags.Environment == "" {
 					return nil, "Please provide environment to auto-complete job names. '-e, --environment <environment>' flag."

--- a/internal/log/command/log.go
+++ b/internal/log/command/log.go
@@ -30,7 +30,7 @@ func Log(parentFlags *flag.Alpha) *naistrix.Command {
 			}
 
 			if len(flags.Team) == 0 {
-				return fmt.Errorf("team cannot be empty, set team using 'nais config set team <team>' or the --team flag")
+				return fmt.Errorf("team cannot be empty, set team using 'nais defaults set team <team>' or the --team flag")
 			}
 
 			return nil

--- a/internal/opensearch/command/command.go
+++ b/internal/opensearch/command/command.go
@@ -58,7 +58,7 @@ func metadataFromArgs(args *naistrix.Arguments, team string, environment string)
 
 func autoCompleteOpenSearchNames(ctx context.Context, team, environment string, requireEnvironment bool) ([]string, string) {
 	if team == "" {
-		return nil, "Please provide team to auto-complete OpenSearch instance names. 'nais config set team <team>', or '--team <team>' flag."
+		return nil, "Please provide team to auto-complete OpenSearch instance names. 'nais defaults set team <team>', or '--team <team>' flag."
 	}
 
 	if environmentFlagOccurrencesFromCLIArgs() > 1 {

--- a/internal/opensearch/command/flag/flag.go
+++ b/internal/opensearch/command/flag/flag.go
@@ -98,7 +98,7 @@ func (e *GetEnv) AutoComplete(ctx context.Context, args *naistrix.Arguments, str
 
 	f := flags.(*Get)
 	if len(f.Team) == 0 {
-		return nil, "Please provide team to auto-complete environments. 'nais config team set <team>', or '--team <team>' flag."
+		return nil, "Please provide team to auto-complete environments. 'nais defaults set team <team>', or '--team <team>' flag."
 	}
 
 	envs, err := opensearch.OpenSearchEnvironments(ctx, f.Team, args.Get("name"))

--- a/internal/validation/validator.go
+++ b/internal/validation/validator.go
@@ -13,7 +13,7 @@ var CheckEnvironment = func(env string) error {
 
 var CheckTeam = func(team string) error {
 	if team == "" {
-		return fmt.Errorf("team cannot be empty, set team using 'nais config set team <team>' or the --team flag")
+		return fmt.Errorf("team cannot be empty, set team using 'nais defaults set team <team>' or the --team flag")
 	}
 	return nil
 }

--- a/internal/valkey/command/command.go
+++ b/internal/valkey/command/command.go
@@ -60,7 +60,7 @@ func metadataFromArgs(args *naistrix.Arguments, team string, environment string)
 
 func autoCompleteValkeyNames(ctx context.Context, team, environment string, requireEnvironment bool) ([]string, string) {
 	if team == "" {
-		return nil, "Please provide team to auto-complete Valkey instance names. 'nais config set team <team>', or '--team <team>' flag."
+		return nil, "Please provide team to auto-complete Valkey instance names. 'nais defaults set team <team>', or '--team <team>' flag."
 	}
 
 	if environmentFlagOccurrencesFromCLIArgs() > 1 {


### PR DESCRIPTION
## Summary

- Updates 18 stale references across 17 files that still pointed users to the old `nais config set team` (and `nais config team set`) command
- All references now correctly point to `nais defaults set team`