### PR TITLE
feat(app): auto-select or prompt for environment across app subcommands

### DIFF
--- a/internal/app/command/env.go
+++ b/internal/app/command/env.go
@@ -26,7 +26,7 @@ func env(parentFlags *flag.App) *naistrix.Command {
 		RunFunc: func(ctx context.Context, args *naistrix.Arguments, out *naistrix.OutputWriter) error {
 			name := args.Get("name")
 
-			environment, err := resolveAppEnvironment(ctx, out, flags.Team, name, string(flags.Environment))
+			environment, err := resolveAppEnvironment(ctx, out, flags.Team, name, string(flags.Environment), flags.Output == "json")
 			if err != nil {
 				return err
 			}

--- a/internal/app/command/env.go
+++ b/internal/app/command/env.go
@@ -23,11 +23,15 @@ func env(parentFlags *flag.App) *naistrix.Command {
 			{Name: "name"},
 		},
 		Flags: flags,
-		ValidateFunc: func(context.Context, *naistrix.Arguments) error {
-			return requireSingleEnvironment(flags.Environment)
-		},
 		RunFunc: func(ctx context.Context, args *naistrix.Arguments, out *naistrix.OutputWriter) error {
-			ret, err := app.GetApplicationEnvVars(ctx, flags.Team, args.Get("name"), flags.Environment)
+			name := args.Get("name")
+
+			environment, err := resolveAppEnvironment(ctx, out, flags.Team, name, string(flags.Environment))
+			if err != nil {
+				return err
+			}
+
+			ret, err := app.GetApplicationEnvVars(ctx, flags.Team, name, environment)
 			if err != nil {
 				return err
 			}
@@ -47,7 +51,7 @@ func env(parentFlags *flag.App) *naistrix.Command {
 
 			if secretNames := app.UniqueSecretNames(ret); len(secretNames) > 0 {
 				out.Println("")
-				out.Printf("Secret values hidden. Use 'nais secret view <name> -e %s' to reveal.\n", flags.Environment[0])
+				out.Printf("Secret values hidden. Use 'nais secret view <name> -e %s' to reveal.\n", environment)
 				out.Printf("Secrets in use: %s\n", strings.Join(secretNames, ", "))
 			}
 

--- a/internal/app/command/environment.go
+++ b/internal/app/command/environment.go
@@ -1,0 +1,62 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/nais/cli/internal/app"
+	"github.com/nais/naistrix"
+	"github.com/nais/naistrix/input"
+	"golang.org/x/term"
+)
+
+// resolveAppEnvironment determines which environment to use for a command operating on
+// a single application.
+//
+//   - If provided is non-empty, it is validated against the environments where the
+//     application exists.
+//   - If provided is empty and the application exists in exactly one environment,
+//     that environment is auto-selected and a notice is printed via out.
+//   - If provided is empty and the application exists in multiple environments,
+//     an interactive selector is shown when running in a terminal. In a non-interactive
+//     context (CI, pipes), a clear error is returned listing the available environments.
+//   - If the application is not found in any environment, an error is returned.
+func resolveAppEnvironment(ctx context.Context, out *naistrix.OutputWriter, team, name, provided string) (string, error) {
+	envs, err := app.ApplicationEnvironments(ctx, team, name)
+	if err != nil {
+		return "", fmt.Errorf("fetching environments for application %q: %w", name, err)
+	}
+
+	if provided != "" {
+		if slices.Contains(envs, provided) {
+			return provided, nil
+		}
+		if len(envs) == 0 {
+			return "", fmt.Errorf("application %q not found in team %q", name, team)
+		}
+		sort.Strings(envs)
+		return "", fmt.Errorf("application %q does not exist in environment %q; available environments: %s", name, provided, strings.Join(envs, ", "))
+	}
+
+	switch len(envs) {
+	case 0:
+		return "", fmt.Errorf("application %q not found in team %q", name, team)
+	case 1:
+		out.Infof("%s only found in %s, auto-selecting.\n", name, envs[0])
+		return envs[0], nil
+	default:
+		sort.Strings(envs)
+		if !term.IsTerminal(int(os.Stdin.Fd())) { // #nosec G115
+			return "", fmt.Errorf("application %q exists in multiple environments (%s); specify -e, --environment", name, strings.Join(envs, ", "))
+		}
+		selected, err := input.Select(fmt.Sprintf("Select environment for %s", name), envs)
+		if err != nil {
+			return "", fmt.Errorf("selecting environment: %w", err)
+		}
+		return selected, nil
+	}
+}

--- a/internal/app/command/environment.go
+++ b/internal/app/command/environment.go
@@ -53,7 +53,11 @@ func resolveAppEnvironment(ctx context.Context, out *naistrix.OutputWriter, team
 		return envs[0], nil
 	default:
 		sort.Strings(envs)
-		if !term.IsTerminal(int(os.Stdin.Fd())) { // #nosec G115
+		// Only prompt when both stdin and stdout are terminals: stdin so we can
+		// read the user's choice, stdout so the user actually sees the prompt.
+		// In pipelines like `nais app status <app> | jq ...`, stdout is a pipe
+		// and we must fail clearly instead of blocking on hidden input.
+		if !term.IsTerminal(int(os.Stdin.Fd())) || !term.IsTerminal(int(os.Stdout.Fd())) { // #nosec G115
 			return "", fmt.Errorf("application %q exists in multiple environments (%s); specify -e, --environment", name, strings.Join(envs, ", "))
 		}
 		selected, err := input.Select(fmt.Sprintf("Select environment for %s", name), envs)

--- a/internal/app/command/environment.go
+++ b/internal/app/command/environment.go
@@ -20,12 +20,13 @@ import (
 //   - If provided is non-empty, it is validated against the environments where the
 //     application exists.
 //   - If provided is empty and the application exists in exactly one environment,
-//     that environment is auto-selected and a notice is printed via out.
+//     that environment is auto-selected and a notice is printed via out, unless
+//     quiet is true (e.g. when machine-readable output like JSON is requested).
 //   - If provided is empty and the application exists in multiple environments,
 //     an interactive selector is shown when running in a terminal. In a non-interactive
 //     context (CI, pipes), a clear error is returned listing the available environments.
 //   - If the application is not found in any environment, an error is returned.
-func resolveAppEnvironment(ctx context.Context, out *naistrix.OutputWriter, team, name, provided string) (string, error) {
+func resolveAppEnvironment(ctx context.Context, out *naistrix.OutputWriter, team, name, provided string, quiet bool) (string, error) {
 	envs, err := app.ApplicationEnvironments(ctx, team, name)
 	if err != nil {
 		return "", fmt.Errorf("fetching environments for application %q: %w", name, err)
@@ -46,7 +47,9 @@ func resolveAppEnvironment(ctx context.Context, out *naistrix.OutputWriter, team
 	case 0:
 		return "", fmt.Errorf("application %q not found in team %q", name, team)
 	case 1:
-		out.Infof("%s only found in %s, auto-selecting.\n", name, envs[0])
+		if !quiet {
+			out.Infof("%s only found in %s, auto-selecting.\n", name, envs[0])
+		}
 		return envs[0], nil
 	default:
 		sort.Strings(envs)

--- a/internal/app/command/files.go
+++ b/internal/app/command/files.go
@@ -22,11 +22,15 @@ func files(parentFlags *flag.App) *naistrix.Command {
 			{Name: "name"},
 		},
 		Flags: flags,
-		ValidateFunc: func(context.Context, *naistrix.Arguments) error {
-			return requireSingleEnvironment(flags.Environment)
-		},
 		RunFunc: func(ctx context.Context, args *naistrix.Arguments, out *naistrix.OutputWriter) error {
-			ret, err := app.GetApplicationFiles(ctx, flags.Team, args.Get("name"), flags.Environment)
+			name := args.Get("name")
+
+			environment, err := resolveAppEnvironment(ctx, out, flags.Team, name, string(flags.Environment), flags.Output == "json")
+			if err != nil {
+				return err
+			}
+
+			ret, err := app.GetApplicationFiles(ctx, flags.Team, name, environment)
 			if err != nil {
 				return err
 			}
@@ -46,7 +50,7 @@ func files(parentFlags *flag.App) *naistrix.Command {
 
 			if app.HasSecretFiles(ret) {
 				out.Println("")
-				out.Printf("To view secret contents, use 'nais secret view <name> -e %s'.\n", flags.Environment[0])
+				out.Printf("To view secret contents, use 'nais secret view <name> -e %s'.\n", environment)
 			}
 
 			return nil

--- a/internal/app/command/flag/flag.go
+++ b/internal/app/command/flag/flag.go
@@ -89,16 +89,27 @@ func (e *Env) AutoComplete(ctx context.Context, args *naistrix.Arguments, str st
 		return autoCompleteEnvironments(ctx)
 	}
 
-	f := flags.(*Log)
-	if len(f.Team) == 0 {
+	team := teamFromAppFlags(flags)
+	if len(team) == 0 {
 		return nil, "Please provide team to auto-complete environments. 'nais defaults set team <team>', or '--team <team>' flag."
 	}
 
-	envs, err := app.ApplicationEnvironments(ctx, f.Team, args.Get("name"))
+	envs, err := app.ApplicationEnvironments(ctx, team, args.Get("name"))
 	if err != nil {
 		return nil, fmt.Sprintf("Failed to fetch environments for auto-completion: %v", err)
 	}
 	return envs, "Available environments"
+}
+
+func teamFromAppFlags(flags any) string {
+	switch f := flags.(type) {
+	case *Log:
+		return f.Team
+	case *EnvVars:
+		return f.Team
+	default:
+		return ""
+	}
 }
 
 type Log struct {
@@ -119,6 +130,7 @@ type Status struct {
 
 type EnvVars struct {
 	*App
+	Environment Env `name:"environment" short:"e" usage:"Environment of the application. Auto-selected if the app exists in only one environment."`
 }
 
 type Files struct {

--- a/internal/app/command/flag/flag.go
+++ b/internal/app/command/flag/flag.go
@@ -18,6 +18,12 @@ type App struct {
 	Environment Environments `name:"environment" short:"e" usage:"Filter by environment."`
 	Output      Output       `name:"output" short:"o" usage:"Format output (table or json)."`
 }
+
+func (a *App) GetTeam() string { return a.Team }
+
+type teamScoped interface {
+	GetTeam() string
+}
 type Environments []string
 
 func (e *Environments) AutoComplete(ctx context.Context, args *naistrix.Arguments, str string, flags any) ([]string, string) {
@@ -35,7 +41,10 @@ func (i *instances) AutoComplete(ctx context.Context, args *naistrix.Arguments, 
 		return nil, "Please provide an application name to auto-complete instances."
 	}
 
-	f := flags.(*Log)
+	f, ok := flags.(*Log)
+	if !ok {
+		return nil, ""
+	}
 	if len(f.Environment) == 0 {
 		return nil, "Please provide environment (-e, --environment) to auto-complete instances."
 	}
@@ -44,7 +53,7 @@ func (i *instances) AutoComplete(ctx context.Context, args *naistrix.Arguments, 
 		return nil, "Please provide team to auto-complete instances. 'nais defaults set team <team>', or '--team <team>' flag."
 	}
 
-	instances, err := app.GetApplicationInstances(ctx, string(f.Team), args.Get("name"), string(f.Environment))
+	instances, err := app.GetApplicationInstances(ctx, f.Team, args.Get("name"), string(f.Environment))
 	if err != nil {
 		return nil, fmt.Sprintf("Failed to fetch instances for auto-completion: %v", err)
 	}
@@ -61,6 +70,7 @@ func (o *Output) AutoComplete(context.Context, *naistrix.Arguments, string, any)
 
 type Restart struct {
 	*App
+	Environment Env `name:"environment" short:"e" usage:"Environment of the application. Auto-selected if the app exists in only one environment."`
 }
 
 type Issues struct {
@@ -89,7 +99,11 @@ func (e *Env) AutoComplete(ctx context.Context, args *naistrix.Arguments, str st
 		return autoCompleteEnvironments(ctx)
 	}
 
-	team := teamFromAppFlags(flags)
+	ts, ok := flags.(teamScoped)
+	if !ok {
+		return nil, ""
+	}
+	team := ts.GetTeam()
 	if len(team) == 0 {
 		return nil, "Please provide team to auto-complete environments. 'nais defaults set team <team>', or '--team <team>' flag."
 	}
@@ -101,20 +115,9 @@ func (e *Env) AutoComplete(ctx context.Context, args *naistrix.Arguments, str st
 	return envs, "Available environments"
 }
 
-func teamFromAppFlags(flags any) string {
-	switch f := flags.(type) {
-	case *Log:
-		return f.Team
-	case *EnvVars:
-		return f.Team
-	default:
-		return ""
-	}
-}
-
 type Log struct {
 	*App
-	Environment    Env           `name:"environment" short:"e" usage:"Filter by environment."`
+	Environment    Env           `name:"environment" short:"e" usage:"Environment of the application. Auto-selected if the app exists in only one environment."`
 	Instance       instances     `name:"instance" short:"i" usage:"Filter by instance. Can be repeated"`
 	Container      []string      `name:"container" short:"c" usage:"Filter logs to a specific |container|. Can be repeated."`
 	WithTimestamps bool          `name:"with-timestamps" usage:"Include timestamps in log output."`
@@ -126,6 +129,7 @@ type Log struct {
 
 type Status struct {
 	*App
+	Environment Env `name:"environment" short:"e" usage:"Environment of the application. Auto-selected if the app exists in only one environment."`
 }
 
 type EnvVars struct {
@@ -135,6 +139,7 @@ type EnvVars struct {
 
 type Files struct {
 	*App
+	Environment Env `name:"environment" short:"e" usage:"Environment of the application. Auto-selected if the app exists in only one environment."`
 }
 
 func autoCompleteEnvironments(ctx context.Context) ([]string, string) {

--- a/internal/app/command/helpers.go
+++ b/internal/app/command/helpers.go
@@ -8,15 +8,6 @@ import (
 	"github.com/nais/naistrix"
 )
 
-// requireSingleEnvironment validates that exactly one environment is specified.
-func requireSingleEnvironment(envs flag.Environments) error {
-	if len(envs) != 1 {
-		return naistrix.Errorf("exactly one environment must be specified with -e/--environment")
-	}
-	return nil
-}
-
-// autoCompleteAppNames returns an AutoCompleteFunc that completes application names for the given flags.
 func autoCompleteAppNames(flags *flag.App) func(context.Context, *naistrix.Arguments, string) ([]string, string) {
 	return func(ctx context.Context, args *naistrix.Arguments, _ string) ([]string, string) {
 		if args.Len() == 0 {

--- a/internal/app/command/log.go
+++ b/internal/app/command/log.go
@@ -28,31 +28,26 @@ func log(parentFlags *flag.App) *naistrix.Command {
 			{Name: "name"},
 		},
 		Flags: flags,
-		ValidateFunc: func(ctx context.Context, args *naistrix.Arguments) error {
-			if flags.Environment == "" {
-				return fmt.Errorf("exactly one environment must be specified")
-			}
-			if args.Get("name") == "" {
-				return fmt.Errorf("application name is required")
-			}
-
-			return nil
-		},
 		RunFunc: func(ctx context.Context, args *naistrix.Arguments, out *naistrix.OutputWriter) error {
 			user, err := naisapi.GetAuthenticatedUser(ctx)
 			if err != nil {
 				return fmt.Errorf("unable to get authenticated user: %w", err)
 			}
 
-			queryEnvironment := flags.Environment
-			if user.Domain() == "nav.no" {
-				queryEnvironment = flag.Env(strings.TrimSuffix(string(queryEnvironment), "-gcp"))
-			}
 			appName := args.Get("name")
+			environment, err := resolveAppEnvironment(ctx, out, flags.Team, appName, string(flags.Environment), false)
+			if err != nil {
+				return err
+			}
+
+			queryEnvironment := environment
+			if user.Domain() == "nav.no" {
+				queryEnvironment = strings.TrimSuffix(environment, "-gcp")
+			}
 			query := flags.RawQuery
 			if query == "" {
 				query = logs.NewQueryBuilder().
-					AddEnvironments(string(queryEnvironment)).
+					AddEnvironments(queryEnvironment).
 					AddTeams(flags.Team).
 					AddWorkloads(appName).
 					AddContainers(flags.Container...).
@@ -60,7 +55,7 @@ func log(parentFlags *flag.App) *naistrix.Command {
 					Build()
 			}
 
-			if err := naisapi.TailLog(ctx, out, string(flags.Environment), flags.Limit, flags.Since, flags.WithTimestamps, flags.WithLabels, query); err != nil {
+			if err := naisapi.TailLog(ctx, out, environment, flags.Limit, flags.Since, flags.WithTimestamps, flags.WithLabels, query); err != nil {
 				return fmt.Errorf("unable to tail logs: %w", err)
 			}
 
@@ -71,11 +66,12 @@ func log(parentFlags *flag.App) *naistrix.Command {
 				if len(flags.Team) == 0 {
 					return nil, "Please provide team to auto-complete application names. 'nais defaults set team <team>', or '--team <team>' flag."
 				}
-				if flags.Environment == "" {
-					return nil, "Please provide environment to auto-complete application names. '-e, --environment <environment>' flag."
-				}
 
-				apps, err := app.GetApplicationNames(ctx, flags.Team, []string{string(flags.Environment)})
+				envs := []string{}
+				if flags.Environment != "" {
+					envs = []string{string(flags.Environment)}
+				}
+				apps, err := app.GetApplicationNames(ctx, flags.Team, envs)
 				if err != nil {
 					return nil, "Unable to fetch application names."
 				}

--- a/internal/app/command/restart.go
+++ b/internal/app/command/restart.go
@@ -16,7 +16,7 @@ func restart(parentFlags *flag.App) *naistrix.Command {
 	return &naistrix.Command{
 		Name:        "restart",
 		Title:       "Restart an application.",
-		Description: "Triggers a rolling restart of the application in the specified environment. If the application exists in only one environment, it is auto-selected; otherwise an interactive prompt is shown when running in a terminal.",
+		Description: "Triggers a rolling restart of the application.",
 		Flags:       flags,
 		Args: []naistrix.Argument{
 			{Name: "name"},

--- a/internal/app/command/restart.go
+++ b/internal/app/command/restart.go
@@ -16,13 +16,20 @@ func restart(parentFlags *flag.App) *naistrix.Command {
 	return &naistrix.Command{
 		Name:        "restart",
 		Title:       "Restart an application.",
-		Description: "Triggers a rolling restart of the application in the specified environment. Requires exactly one environment to be specified.",
+		Description: "Triggers a rolling restart of the application in the specified environment. If the application exists in only one environment, it is auto-selected; otherwise an interactive prompt is shown when running in a terminal.",
 		Flags:       flags,
 		Args: []naistrix.Argument{
 			{Name: "name"},
 		},
 		RunFunc: func(ctx context.Context, args *naistrix.Arguments, out *naistrix.OutputWriter) error {
-			ret, err := app.RestartApp(ctx, flags.Team, args.Get("name"), flags.Environment)
+			name := args.Get("name")
+
+			environment, err := resolveAppEnvironment(ctx, out, flags.Team, name, string(flags.Environment), false)
+			if err != nil {
+				return err
+			}
+
+			ret, err := app.RestartApp(ctx, flags.Team, name, environment)
 			if err != nil {
 				return err
 			}
@@ -30,5 +37,6 @@ func restart(parentFlags *flag.App) *naistrix.Command {
 			out.Println(ret)
 			return nil
 		},
+		AutoCompleteFunc: autoCompleteAppNames(flags.App),
 	}
 }

--- a/internal/app/command/status.go
+++ b/internal/app/command/status.go
@@ -24,11 +24,15 @@ func status(parentFlags *flag.App) *naistrix.Command {
 			{Name: "name"},
 		},
 		Flags: flags,
-		ValidateFunc: func(context.Context, *naistrix.Arguments) error {
-			return requireSingleEnvironment(flags.Environment)
-		},
 		RunFunc: func(ctx context.Context, args *naistrix.Arguments, out *naistrix.OutputWriter) error {
-			ret, err := app.GetApplicationStatus(ctx, flags.Team, args.Get("name"), flags.Environment)
+			name := args.Get("name")
+
+			environment, err := resolveAppEnvironment(ctx, out, flags.Team, name, string(flags.Environment), flags.Output == "json")
+			if err != nil {
+				return err
+			}
+
+			ret, err := app.GetApplicationStatus(ctx, flags.Team, name, environment)
 			if err != nil {
 				return err
 			}

--- a/internal/app/envvars.go
+++ b/internal/app/envvars.go
@@ -53,7 +53,7 @@ type EnvVar struct {
 	Source ValueSource `json:"source"`
 }
 
-func GetApplicationEnvVars(ctx context.Context, slug, name string, envs []string) ([]EnvVar, error) {
+func GetApplicationEnvVars(ctx context.Context, slug, name, env string) ([]EnvVar, error) {
 	_ = `# @genqlient
 		query GetApplicationEnvVars($slug: Slug!, $name: String!, $env: [String!]) {
 		  team(slug: $slug) {
@@ -81,7 +81,7 @@ func GetApplicationEnvVars(ctx context.Context, slug, name string, envs []string
 		return nil, err
 	}
 
-	resp, err := gql.GetApplicationEnvVars(ctx, client, slug, name, envs)
+	resp, err := gql.GetApplicationEnvVars(ctx, client, slug, name, []string{env})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/files.go
+++ b/internal/app/files.go
@@ -32,7 +32,7 @@ type MountedFile struct {
 	Error  MountedFileError `json:"error"`
 }
 
-func GetApplicationFiles(ctx context.Context, slug, name string, envs []string) ([]MountedFile, error) {
+func GetApplicationFiles(ctx context.Context, slug, name, env string) ([]MountedFile, error) {
 	_ = `# @genqlient
 		query GetApplicationFiles($slug: Slug!, $name: String!, $env: [String!]) {
 		  team(slug: $slug) {
@@ -60,7 +60,7 @@ func GetApplicationFiles(ctx context.Context, slug, name string, envs []string) 
 		return nil, err
 	}
 
-	resp, err := gql.GetApplicationFiles(ctx, client, slug, name, envs)
+	resp, err := gql.GetApplicationFiles(ctx, client, slug, name, []string{env})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/restart.go
+++ b/internal/app/restart.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nais/cli/internal/naisapi/gql"
 )
 
-func RestartApp(ctx context.Context, team, application string, envs []string) (string, error) {
+func RestartApp(ctx context.Context, team, application, env string) (string, error) {
 	_ = `# @genqlient
 		mutation RestartApp($team: Slug!, $application: String!, $env: String!) {
 		  restartApplication(
@@ -25,14 +25,9 @@ func RestartApp(ctx context.Context, team, application string, envs []string) (s
 	if err != nil {
 		return "failed restarting application", err
 	}
-	if len(envs) != 1 {
-		return "please specify exactly one environment to restart the application in", fmt.Errorf("exactly one environment must be specified")
-	}
-	env := envs[0]
 
-	_, err = gql.RestartApp(ctx, client, team, application, env)
-	if err != nil {
-		return "failed restarting applicatioon", err
+	if _, err := gql.RestartApp(ctx, client, team, application, env); err != nil {
+		return "failed restarting application", err
 	}
 	return fmt.Sprintf("Successfully restarted %v in %v", application, env), nil
 }

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -51,7 +51,7 @@ type InstanceGroupInfo struct {
 	Instances        []InstanceInfo `json:"instances"`
 }
 
-func GetApplicationStatus(ctx context.Context, slug, name string, envs []string) (*InstanceGroupStatus, error) {
+func GetApplicationStatus(ctx context.Context, slug, name, env string) (*InstanceGroupStatus, error) {
 	_ = `# @genqlient
 		query GetApplicationStatus($slug: Slug!, $name: String!, $env: [String!]) {
 		  team(slug: $slug) {
@@ -96,7 +96,7 @@ func GetApplicationStatus(ctx context.Context, slug, name string, envs []string)
 		return nil, err
 	}
 
-	resp, err := gql.GetApplicationStatus(ctx, client, slug, name, envs)
+	resp, err := gql.GetApplicationStatus(ctx, client, slug, name, []string{env})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Forbedrer UX for `nais app <cmd>` (env, status, files, restart, log) når `-e/--environment` ikke er angitt:

- **App finnes i kun ett miljø** → auto-velg det og print en tydelig notice (`INFO: <app> only found in <env>, auto-selecting.`).
- **App finnes i flere miljøer (TTY)** → vis interaktiv `input.Select`.
- **App finnes i flere miljøer (ikke-TTY / CI / pipe)** → feil tydelig med listen over tilgjengelige miljøer i stedet for å prompte.
- **Wrong `-e`** → bedre feilmelding som lister tilgjengelige miljøer.
- **Auto-select notice suppressed ved `-o json`** så machine-readable output forblir gyldig JSON.

Mønsteret er konsistent på tvers av alle `nais app`-subkommandoer som opererer på én app i ett miljø.

## Hva endres

### UX-pattern
Ny helper `resolveAppEnvironment(ctx, out, team, name, provided, quiet)` i `internal/app/command/environment.go` håndterer all env-resolving for app-subkommandoer. Brukes av `env`, `status`, `files`, `restart`, `log`.

### Flag-foundation
- `flag.App.GetTeam()` + `teamScoped`-interface i `Env.AutoComplete`. Flag-structer som embedder `*App` får korrekt env-autocomplete uten å måtte oppdateres i `flag.go`.
- `flag.{Status, Files, Restart, EnvVars}` overstyrer den arvede multi-valued `Environments` med single `Env`, siden disse semantisk tar nøyaktig ett miljø. `flag.App.Environment` (multi) er uendret og brukes fortsatt av `nais app list`.

### API-signaturer
`GetApplicationStatus`, `GetApplicationFiles`, `RestartApp`, `GetApplicationEnvVars` tar nå single `env string` i stedet for `envs []string`. GraphQL-laget er uendret.

### Cleanup
- `restart` har nå `AutoCompleteFunc` for app-navn (manglet før).
- `app log` bevarer sin spesielle nav.no-domene-transformasjon (`-gcp`-stripping) for Loki-spørringer; auto-select-helperen returnerer alltid det "ekte" miljønavnet.

## Behaviors verified live

| Kommando | Scenario | Result |
|---|---|---|
| `app env` | 1 env (auto-select) | Notice + tabell |
| `app env` | 1 env, `-o json` | Gyldig JSON, ingen notice |
| `app env` | `-e <feil>` | `does not exist in environment "x"; available environments: ...` |
| `app status` | 1 env (auto-select) | Notice + status |
| `app status` | multi env, ikke-TTY | Tydelig feil med liste |
| `app status` | 1 env, `-o json` | Gyldig JSON |
| `app status` | `-e <feil>` | `does not exist in environment "x"; available environments: ...` |
| `app files` | 1 env (auto-select) | Notice + filtabell |
| `app files` | multi env, ikke-TTY | Tydelig feil med liste |
| `app restart` | ikke-eksisterende app | `application "x" not found in team "y"` |
| `app restart` | `-e <feil>` | `does not exist in environment "x"; available environments: ...` |
| Alle | ikke-eksisterende app | `application "x" not found in team "y"` |

## Notater

- Repeated `-e` (f.eks. `-e dev -e prod`) avvises ikke eksplisitt – flag-typen er single `Env`, så siste-vinner gjelder (standard CLI-konvensjon for ikke-slice string-flagg). Kan strammes til senere hvis ønskelig.
- Mønsteret kan generaliseres utenfor `nais app` (secret, config, opensearch, valkey, kafka) i en oppfølger når vi har sett hvordan dette kjenner i bruk.