### PR TITLE
fix(kafka): show app name alongside SASL username and accept either in grant-access

### DIFF
--- a/internal/kafka/command/credentials.go
+++ b/internal/kafka/command/credentials.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -144,6 +145,18 @@ func printMultilineEnvVar(out *naistrix.OutputWriter, name, value, marker string
 	out.Println(")")
 }
 
+var saslUsernameRe = regexp.MustCompile(`^[a-z0-9-]{1,20}_([a-z0-9-]{1,30})_[a-f0-9]{8}_[A-Za-z0-9]{1,8}$`)
+
+// kafkaApplicationName returns the application-name segment of a Nais Kafka SASL
+// username (the value used by `nais kafka grant-access`). Returns the input
+// unchanged if it doesn't match the SASL format.
+func kafkaApplicationName(username string) string {
+	if m := saslUsernameRe.FindStringSubmatch(username); m != nil {
+		return m[1]
+	}
+	return username
+}
+
 func writeKafkaKcat(out *naistrix.OutputWriter, creds *gql.CreateKafkaCredentialsCreateKafkaCredentialsCreateKafkaCredentialsPayloadCredentialsKafkaCredentials) error {
 	files, err := writeCertFiles(creds)
 	if err != nil {
@@ -157,7 +170,7 @@ func writeKafkaKcat(out *naistrix.OutputWriter, creds *gql.CreateKafkaCredential
 	config.WriteString(fmt.Sprintf("# nais-cli %s\n# kcat -F %s -t your.topic\n",
 		time.Now().Truncate(time.Minute), configFile))
 	config.WriteString(fmt.Sprintf("bootstrap.servers=%s\n", creds.Brokers))
-	config.WriteString(fmt.Sprintf("# username=%s\n", creds.Username))
+	config.WriteString(fmt.Sprintf("# sasl.username=%s (use %q with 'nais kafka grant-access')\n", creds.Username, kafkaApplicationName(creds.Username)))
 	config.WriteString("security.protocol=ssl\n")
 	config.WriteString(fmt.Sprintf("ssl.certificate.location=%s\n", files.cert))
 	config.WriteString(fmt.Sprintf("ssl.key.location=%s\n", files.key))
@@ -189,7 +202,7 @@ func writeKafkaJava(out *naistrix.OutputWriter, creds *gql.CreateKafkaCredential
 	properties.WriteString(fmt.Sprintf("# nais-cli %s\n", time.Now().Truncate(time.Minute)))
 	properties.WriteString(fmt.Sprintf("# Usage: kafka-console-consumer.sh --topic your.topic --bootstrap-server %s --consumer.config %s\n",
 		creds.Brokers, configFile))
-	properties.WriteString(fmt.Sprintf("# username=%s\n", creds.Username))
+	properties.WriteString(fmt.Sprintf("# sasl.username=%s (use %q with 'nais kafka grant-access')\n", creds.Username, kafkaApplicationName(creds.Username)))
 	properties.WriteString("security.protocol=SSL\n")
 	properties.WriteString("ssl.protocol=TLS\n")
 	properties.WriteString(fmt.Sprintf("ssl.truststore.location=%s\n", filepath.ToSlash(files.ca)))

--- a/internal/kafka/command/credentials_test.go
+++ b/internal/kafka/command/credentials_test.go
@@ -18,7 +18,7 @@ func newTestOutputWriter(buf *bytes.Buffer) *naistrix.OutputWriter {
 
 func testKafkaCreds() *gql.CreateKafkaCredentialsCreateKafkaCredentialsCreateKafkaCredentialsPayloadCredentialsKafkaCredentials {
 	return &gql.CreateKafkaCredentialsCreateKafkaCredentialsCreateKafkaCredentialsPayloadCredentialsKafkaCredentials{
-		Username:       "alice",
+		Username:       "myteam_alice_deadbeef_99",
 		AccessCert:     "-----BEGIN CERTIFICATE-----\ntest-cert\n-----END CERTIFICATE-----",
 		AccessKey:      "-----BEGIN PRIVATE KEY-----\ntest-key\n-----END PRIVATE KEY-----",
 		CaCert:         "-----BEGIN CERTIFICATE-----\ntest-ca\n-----END CERTIFICATE-----",
@@ -90,9 +90,9 @@ func TestWriteKafkaEnv(t *testing.T) {
 	got := buf.String()
 	for _, want := range []string{
 		`KAFKA_BROKERS="broker1:9092,broker2:9092"`,
-		`KAFKA_USERNAME="alice"`,
+		`KAFKA_USERNAME="myteam_alice_deadbeef_99"`,
 		`KAFKA_SCHEMA_REGISTRY="https://schema-registry:8081"`,
-		`KAFKA_SCHEMA_REGISTRY_USER="alice"`,
+		`KAFKA_SCHEMA_REGISTRY_USER="myteam_alice_deadbeef_99"`,
 		"KAFKA_CERTIFICATE=$(cat <<'NAIS_KAFKA_CERT_EOF'",
 		"KAFKA_PRIVATE_KEY=$(cat <<'NAIS_KAFKA_KEY_EOF'",
 		"KAFKA_CA=$(cat <<'NAIS_KAFKA_CA_EOF'",
@@ -136,7 +136,7 @@ func TestWriteKafkaKcat(t *testing.T) {
 	for _, want := range []string{
 		"# nais-cli ",
 		"bootstrap.servers=broker1:9092,broker2:9092",
-		"# username=alice",
+		`# sasl.username=myteam_alice_deadbeef_99 (use "alice" with 'nais kafka grant-access')`,
 		"security.protocol=ssl",
 	} {
 		if !strings.Contains(text, want) {
@@ -174,13 +174,28 @@ func TestWriteKafkaJava(t *testing.T) {
 	text := string(content)
 	for _, want := range []string{
 		"# nais-cli ",
-		"# username=alice",
+		`# sasl.username=myteam_alice_deadbeef_99 (use "alice" with 'nais kafka grant-access')`,
 		"security.protocol=SSL",
 		"ssl.truststore.type=PEM",
 		"ssl.keystore.type=PEM",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("Java config missing %q\n%s", want, text)
+		}
+	}
+}
+
+func TestKafkaApplicationName(t *testing.T) {
+	for _, tc := range []struct {
+		in, want string
+	}{
+		{"tsm_tmp-kafka-topic-4cea36_50d5a466_pF5", "tmp-kafka-topic-4cea36"},
+		{"redundant-team_application_18515795_99", "application"},
+		{"my-app", "my-app"},
+		{"", ""},
+	} {
+		if got := kafkaApplicationName(tc.in); got != tc.want {
+			t.Errorf("kafkaApplicationName(%q) = %q, want %q", tc.in, got, tc.want)
 		}
 	}
 }

--- a/internal/kafka/command/grant_access.go
+++ b/internal/kafka/command/grant_access.go
@@ -32,7 +32,7 @@ func grantAccess(parentFlags *flag.Kafka) *naistrix.Command {
 			access := grantAccessTopicFlags.Access
 			namespace := grantAccessTopicFlags.Team
 			topicName := args.Get("topic")
-			username := args.Get("username")
+			username := kafkaApplicationName(args.Get("username"))
 
 			if err := aiven.ValidAclPermission(access); err != nil {
 				return err


### PR DESCRIPTION
## Problem

User report: the kcat/Java config files written by `nais kafka credentials` show

```
# username=tsm_tmp-kafka-topic-4cea36_50d5a466_pF5
```

but `nais kafka grant-access USERNAME TOPIC` expects `tmp-kafka-topic-4cea36`. Users have to clip both ends of the value.

## Fix

Comment now shows both values, and `grant-access` accepts either form:

```
# sasl.username=tsm_tmp-kafka-topic-4cea36_50d5a466_pF5 (use "tmp-kafka-topic-4cea36" with 'nais kafka grant-access')
```

A small regex parses the SASL format from liberator's `ServiceUserNameWithSuffix` to extract the application segment; bare application names pass through unchanged (they cannot contain underscores per RFC-1123).

## Diff

3 files, +36/-8. Tests + checks green locally.