### PR TITLE
fix(postgres): grant migrator jobs scoped secrets access

### DIFF
--- a/internal/postgres/migrate/migrate.go
+++ b/internal/postgres/migrate/migrate.go
@@ -429,6 +429,36 @@ func createObject[T interface {
 	return nil
 }
 
+// makeMigratorRole grants the migrator jobs read access to exactly the two
+// secrets they read in resolved.ResolveInstance: google-sql-<app> (source creds
+// pre-promote, target creds post-promote) and google-sql-migrator-<app> (target
+// creds via the helper app). Replaces reliance on the nais:developer ClusterRole,
+// which lost secrets:get in nais/system#402.
+func makeMigratorRole(cfg config.Config) (*rbacv1.Role, error) {
+	helperName, err := helperAppName(cfg.AppName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive helper app name: %w", err)
+	}
+
+	appSecretName := "google-sql-" + cfg.AppName
+	helperSecretName := "google-sql-" + helperName
+
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfg.MigrationName(),
+			Namespace: cfg.Team,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{""},
+				Resources:     []string{"secrets"},
+				Verbs:         []string{"get", "list", "watch"},
+				ResourceNames: []string{appSecretName, helperSecretName},
+			},
+		},
+	}, nil
+}
+
 func makeRoleBinding(cfg config.Config) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -454,8 +484,8 @@ func makeRoleBinding(cfg config.Config) *rbacv1.RoleBinding {
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
-			Kind:     "ClusterRole",
-			Name:     "nais:developer",
+			Kind:     "Role",
+			Name:     cfg.MigrationName(),
 			APIGroup: "rbac.authorization.k8s.io",
 		},
 	}

--- a/internal/postgres/migrate/setup.go
+++ b/internal/postgres/migrate/setup.go
@@ -79,6 +79,15 @@ func (m *Migrator) Setup(ctx context.Context) error {
 		return fmt.Errorf("failed to create ConfigMap: %w", err)
 	}
 
+	role, err := makeMigratorRole(m.cfg)
+	if err != nil {
+		return err
+	}
+	err = createObject(ctx, m, cfgMap, role, CommandSetup)
+	if err != nil {
+		return err
+	}
+
 	roleBinding := makeRoleBinding(m.cfg)
 	err = createObject(ctx, m, cfgMap, roleBinding, CommandSetup)
 	if err != nil {


### PR DESCRIPTION
## Sammendrag

Fikser at `nais postgres migrate setup` feiler med `secrets "google-sql-<app>" is forbidden` etter at [nais/system#402](https://github.com/nais/system/pull/402) fjernet `secrets:get` fra `nais:developer`-ClusterRole-en.

Migrator-jobbene leser to secrets i `resolved.ResolveInstance`:

- `google-sql-<app>` — source-credentials før promote, target-credentials etter promote (naiserator regenererer secreten i samme navn etter `UpdateApplicationInstance`).
- `google-sql-migrator-<app>` — target-credentials via hjelpe-applikasjonen, som først materialiseres mens jobben kjører (ikke før CLI starter).

Begge livssyklusene gjør at en ren #673-tilnærming (CLI henter via Nais API og sender inn som env) ikke fungerer uten å dele migrator-jobben i flere faser.

## Løsning

Erstatt `RoleBinding → ClusterRole nais:developer` med en namespace-scoped `Role` der `resourceNames` er låst til nøyaktig de to secret-navnene. `RoleBinding` peker nå på denne lokale Role-en i stedet for `nais:developer`.

Role-en eies av migrasjonens ConfigMap og ryddes opp automatisk sammen med resten av migrasjonsressursene, på samme måte som dagens RoleBinding.

### Tilganger før og etter

|                | Før (`nais:developer`)         | Etter (smal Role)              |
| -------------- | ------------------------------ | ------------------------------ |
| Scope          | ClusterRole                    | Namespace-scoped Role          |
| Ressurstyper   | Mange (full `nais:developer`)  | Kun `secrets`                  |
| Ressursnavn    | Alle secrets i namespacet      | To spesifikke navn             |
| Verbs          | Alt `nais:developer` ga        | `get` / `list` / `watch`       |
| Subjekter      | Fire migrator-SA-er            | Samme                          |
| Levetid        | Ryddes opp med ConfigMap       | Samme                          |

Dette er strengere enn det `nais:developer` ga før #402.

### Ingen endringer andre steder

- `cloudsql-migrator` er uendret — jobben leser secrets på samme måte som før.
- `nais/helm-charts` er uendret — ingen sentral ClusterRole-endring.
- promote, rollback og finalize gjenbruker Role og RoleBinding som opprettes i setup.

## Verifisering

- `mise run fmt` ✅
- `mise run test` ✅ (`internal/postgres/migrate` grønn)
- Manuell test mot dev-cluster: gjenstår før merge.

## Mulig oppfølging

Role-definisjonen kan senere flyttes til en sentral ClusterRole i `nais/helm-charts` hvis plattform-teamet foretrekker at RBAC-policy lever i cluster-manifestene heller enn i CLI-kode. Ikke nødvendig for denne fiksen.