### PR TITLE
fix(postgres): limit migrator role verbs to get only

### DIFF
--- a/internal/postgres/migrate/migrate.go
+++ b/internal/postgres/migrate/migrate.go
@@ -434,6 +434,11 @@ func createObject[T interface {
 // pre-promote, target creds post-promote) and google-sql-migrator-<app> (target
 // creds via the helper app). Replaces reliance on the nais:developer ClusterRole,
 // which lost secrets:get in nais/system#402.
+//
+// Verbs are limited to "get" because that is the only verb the migrator uses
+// (resolved.ResolveInstance calls Secrets().Get). Including "list" and "watch"
+// would trigger Kubernetes' privilege escalation prevention for callers that
+// only have "get" on the named secrets.
 func makeMigratorRole(cfg config.Config) (*rbacv1.Role, error) {
 	helperName, err := helperAppName(cfg.AppName)
 	if err != nil {
@@ -452,7 +457,7 @@ func makeMigratorRole(cfg config.Config) (*rbacv1.Role, error) {
 			{
 				APIGroups:     []string{""},
 				Resources:     []string{"secrets"},
-				Verbs:         []string{"get", "list", "watch"},
+				Verbs:         []string{"get"},
 				ResourceNames: []string{appSecretName, helperSecretName},
 			},
 		},


### PR DESCRIPTION
## Summary

The Role created by `nais postgres migrate setup` in [#721](https://github.com/nais/cli/pull/721) declares verbs `["get", "list", "watch"]` on the named secrets, but the migrator only calls `Secrets().Get` in `resolved.ResolveInstance`. The extra verbs are unused.

When a user with only `secrets:get` on the named secrets runs setup, Kubernetes' privilege escalation prevention rejects Role creation because the user cannot grant verbs they don't hold themselves:

```
roles.rbac.authorization.k8s.io "migration-..." is forbidden:
user "..." is attempting to grant RBAC permissions not currently held:
  {APIGroups:[""], Resources:["secrets"], ResourceNames:["google-sql-..."], Verbs:["watch"]}
```

This blocks `nais postgres migrate setup` even when the user has been granted scoped `secrets:get` access. Trimming verbs to `["get"]` matches actual usage and unblocks the escalation check.

## Verification

- `mise run test` ✅
- `lsp_diagnostics` clean