### PR TITLE
fix(postgres): drop CLI-managed RBAC for migrator job

### DIFF
--- a/internal/postgres/migrate/migrate.go
+++ b/internal/postgres/migrate/migrate.go
@@ -20,7 +20,6 @@ import (
 	"golang.org/x/sync/errgroup"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
@@ -427,68 +426,6 @@ func createObject[T interface {
 		return fmt.Errorf("failed to create Object: %w", err)
 	}
 	return nil
-}
-
-// makeMigratorRole grants the migrator jobs read access to exactly the two
-// secrets they read in resolved.ResolveInstance: google-sql-<app> (source creds
-// pre-promote, target creds post-promote) and google-sql-migrator-<app> (target
-// creds via the helper app). Replaces reliance on the nais:developer ClusterRole,
-// which lost secrets:get in nais/system#402.
-func makeMigratorRole(cfg config.Config) (*rbacv1.Role, error) {
-	helperName, err := helperAppName(cfg.AppName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to derive helper app name: %w", err)
-	}
-
-	appSecretName := "google-sql-" + cfg.AppName
-	helperSecretName := "google-sql-" + helperName
-
-	return &rbacv1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cfg.MigrationName(),
-			Namespace: cfg.Team,
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups:     []string{""},
-				Resources:     []string{"secrets"},
-				Verbs:         []string{"get", "list", "watch"},
-				ResourceNames: []string{appSecretName, helperSecretName},
-			},
-		},
-	}, nil
-}
-
-func makeRoleBinding(cfg config.Config) *rbacv1.RoleBinding {
-	return &rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cfg.MigrationName(),
-			Namespace: cfg.Team,
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind: "ServiceAccount",
-				Name: CommandSetup.JobName(cfg),
-			},
-			{
-				Kind: "ServiceAccount",
-				Name: CommandPromote.JobName(cfg),
-			},
-			{
-				Kind: "ServiceAccount",
-				Name: CommandFinalize.JobName(cfg),
-			},
-			{
-				Kind: "ServiceAccount",
-				Name: CommandRollback.JobName(cfg),
-			},
-		},
-		RoleRef: rbacv1.RoleRef{
-			Kind:     "Role",
-			Name:     cfg.MigrationName(),
-			APIGroup: "rbac.authorization.k8s.io",
-		},
-	}
 }
 
 func makeNaisjob(cfg config.Config, imageTag string, command Command) *nais_io_v1.Naisjob {

--- a/internal/postgres/migrate/setup.go
+++ b/internal/postgres/migrate/setup.go
@@ -79,21 +79,6 @@ func (m *Migrator) Setup(ctx context.Context) error {
 		return fmt.Errorf("failed to create ConfigMap: %w", err)
 	}
 
-	role, err := makeMigratorRole(m.cfg)
-	if err != nil {
-		return err
-	}
-	err = createObject(ctx, m, cfgMap, role, CommandSetup)
-	if err != nil {
-		return err
-	}
-
-	roleBinding := makeRoleBinding(m.cfg)
-	err = createObject(ctx, m, cfgMap, roleBinding, CommandSetup)
-	if err != nil {
-		return err
-	}
-
 	jobName, err := m.doNaisJob(ctx, cfgMap, CommandSetup)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

Removes the Role + RoleBinding the CLI was creating during `nais postgres migrate setup`. Platform now grants the migrator service accounts `secrets:get` directly via a namespace-scoped RoleBinding, alongside the developer group's existing access.

## Why

PR #721 had the CLI delegate `secrets:get` to migrator SAs by creating a Role+RoleBinding scoped to two secret names. This worked, but introduced two problems:

1. **Stale bindings**: Migrations set up before v5.27.2 still have RoleBindings pointing at `ClusterRole/nais:developer` (which lost `secrets:get` in nais/system#402). `rollback`/`promote`/`finalize` don't refresh RBAC, so they failed for those migrations even after upgrading the CLI.

2. **Privilege escalation prevention**: For developers granted scoped `secrets:get` (without `watch`), Kubernetes rejected the Role creation outright because the developer cannot delegate verbs they don't hold themselves. PR #722 attempted to trim the verbs to `get`-only, but the underlying model (developer-CLI provisioning RBAC for platform jobs) is fragile against any future grant variation.

Dropping the CLI's RBAC management sidesteps both problems. The grant lives in one place (the platform-managed RoleBinding) and is administered with normal RBAC tooling, not by code running as the end user.

## What changes

- `makeMigratorRole` and `makeRoleBinding` removed.
- `setup.go` no longer creates a Role/RoleBinding before launching the setup job.
- `rbacv1` import removed from `migrate.go`.

## Out of scope / follow-ups

- Long-term, the migrator should authenticate to nais-api via workload identity (nais/system#528) and fetch credentials from there, removing the need for direct k8s secret access. That's a larger change tracked separately.
- Stale ConfigMaps from pre-v5.27.2 migrations still need the workaround (delete ConfigMap, re-run setup) until the platform-side RoleBinding is in place.

## Verification

- `mise run test` ✅
- `mise run fmt` ✅
- `lsp_diagnostics` clean

## Coordination

This change requires the corresponding namespace-scoped RoleBinding to be in place before teams run `nais postgres migrate setup`. Plan to roll out alongside platform deployment of those bindings.