### PR TITLE
fix(postgres): restore RoleBinding to nais:developer for migrator job

### DIFF
--- a/internal/postgres/migrate/migrate.go
+++ b/internal/postgres/migrate/migrate.go
@@ -432,10 +432,6 @@ func createObject[T interface {
 // makeRoleBinding binds the migrator job ServiceAccounts to the nais:developer
 // ClusterRole, granting them the same platform permissions developers have:
 // applications, sqlinstances, deployments/scale, networkpolicies, etc.
-//
-// Secrets:get is granted separately via a platform-managed RoleBinding
-// (tmp-secretreader → nais:secretreader) since nais:developer lost
-// secrets:get in nais/system#402.
 func makeRoleBinding(cfg config.Config) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/postgres/migrate/migrate.go
+++ b/internal/postgres/migrate/migrate.go
@@ -20,6 +20,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
@@ -426,6 +427,45 @@ func createObject[T interface {
 		return fmt.Errorf("failed to create Object: %w", err)
 	}
 	return nil
+}
+
+// makeRoleBinding binds the migrator job ServiceAccounts to the nais:developer
+// ClusterRole, granting them the same platform permissions developers have:
+// applications, sqlinstances, deployments/scale, networkpolicies, etc.
+//
+// Secrets:get is granted separately via a platform-managed RoleBinding
+// (tmp-secretreader → nais:secretreader) since nais:developer lost
+// secrets:get in nais/system#402.
+func makeRoleBinding(cfg config.Config) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfg.MigrationName(),
+			Namespace: cfg.Team,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: "ServiceAccount",
+				Name: CommandSetup.JobName(cfg),
+			},
+			{
+				Kind: "ServiceAccount",
+				Name: CommandPromote.JobName(cfg),
+			},
+			{
+				Kind: "ServiceAccount",
+				Name: CommandFinalize.JobName(cfg),
+			},
+			{
+				Kind: "ServiceAccount",
+				Name: CommandRollback.JobName(cfg),
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     "nais:developer",
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
 }
 
 func makeNaisjob(cfg config.Config, imageTag string, command Command) *nais_io_v1.Naisjob {

--- a/internal/postgres/migrate/setup.go
+++ b/internal/postgres/migrate/setup.go
@@ -79,6 +79,12 @@ func (m *Migrator) Setup(ctx context.Context) error {
 		return fmt.Errorf("failed to create ConfigMap: %w", err)
 	}
 
+	roleBinding := makeRoleBinding(m.cfg)
+	err = createObject(ctx, m, cfgMap, roleBinding, CommandSetup)
+	if err != nil {
+		return err
+	}
+
 	jobName, err := m.doNaisJob(ctx, cfgMap, CommandSetup)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

Restores the RoleBinding the CLI creates for migrator job ServiceAccounts, pointing at `ClusterRole/nais:developer`. Drops the now-unnecessary inline `Role` with `resourceNames`-pinning from #721.

## Why

PR #723 removed all CLI-managed RBAC, on the assumption that a platform-managed RoleBinding (`tmp-secretreader` → `nais:secretreader`) would cover the migrator's k8s API needs. It only covers `secrets:get,list`.

The migrator also needs:
- `namespaces:get` (resolved.go: read `cnrm.cloud.google.com/project-id` annotation)
- `nais.io/applications: *` (helper-app create/get/update/delete)
- `sql.cnrm.cloud.google.com/sqlinstances|sqlssCerts|sqlusers: get,update,patch,create`
- `apps/deployments/scale: update` (UpdateScale during cutover)
- `networking.k8s.io/networkpolicies: create,update,list,delete,deletecollection`

`nais:developer` carries all of these. It lost `secrets:get` in nais/system#402, which is now backfilled by the platform's `tmp-secretreader` RoleBinding (added to namespaces where teams need to run migrations, with `system:serviceaccounts:<team>` as a subject).

Net effect:
- nais:developer → everything except secrets:get
- tmp-secretreader → secrets:get,list
- Together: the migrator can read everything it reads today.

## Why not the inline Role + resourceNames-pinning from #721

That approach delegated only secrets:get on two specific names. It needed the developer running the CLI to hold those exact verbs themselves (privilege escalation prevention), which broke when teams were granted scoped secrets:get without watch (#722 attempted to fix that). With secrets:get now granted via a platform RoleBinding outside the CLI's control, the inline Role is redundant.

## What changes

- Restored `makeRoleBinding` in `internal/postgres/migrate/migrate.go`. RoleRef is `ClusterRole/nais:developer` (not the inline Role from #721).
- Restored the `createObject` call in `setup.go`.
- `makeMigratorRole` from #721 is not restored.

## Coordination

Depends on platform having a RoleBinding in the team's namespace that grants migrator ServiceAccounts `secrets:get`. The current pattern in dev-gcp is `tmp-secretreader` (binds `nais:secretreader` to `system:serviceaccounts:<team>`). This needs to be in place before teams run `nais postgres migrate setup` with this CLI.

## Verification

- `mise run fmt` ✅
- `mise run test` ✅
- `lsp_diagnostics` clean

## Long-term

Workload identity via nais-api (nais/system#528) lets the migrator authenticate to nais-api and fetch what it needs without direct k8s API access. That removes both the `nais:developer` binding and the platform-managed `tmp-secretreader`. Tracked separately.