### PR TITLE
fix: handle empty result in app list and status tables

### DIFF
--- a/internal/app/command/list.go
+++ b/internal/app/command/list.go
@@ -39,6 +39,11 @@ func list(parentFlags *flag.App) *naistrix.Command {
 				return out.JSON(output.JSONWithPrettyOutput()).Render(ret)
 			}
 
+			if len(ret) == 0 {
+				out.Println("No applications found.")
+				return nil
+			}
+
 			user, err := naisapi.GetAuthenticatedUser(ctx)
 			if err != nil {
 				return err

--- a/internal/app/command/status.go
+++ b/internal/app/command/status.go
@@ -98,8 +98,10 @@ func renderStatus(out *naistrix.OutputWriter, status *app.InstanceGroupStatus) e
 			}
 		}
 
-		if err := out.Table().Render(entries); err != nil {
-			return err
+		if len(entries) > 0 {
+			if err := out.Table().Render(entries); err != nil {
+				return err
+			}
 		}
 
 		if len(failingMessages) > 0 {


### PR DESCRIPTION
naistrix Table.Render errors on empty slices. Guard the app list and app status commands so an empty API response (e.g. invalid environment filter or a group with zero instances) prints a message or skips the table instead of crashing.