### PR TITLE
feat(auth): add workload-identity-metadata command

### DIFF
--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -10,7 +10,7 @@ import (
 	activityCommand "github.com/nais/cli/internal/activity/command"
 	alphaCommand "github.com/nais/cli/internal/alpha/command"
 	appCommand "github.com/nais/cli/internal/app/command"
-	"github.com/nais/cli/internal/auth"
+	authCommand "github.com/nais/cli/internal/auth/command"
 	configCommand "github.com/nais/cli/internal/config/command"
 	debugCommand "github.com/nais/cli/internal/debug/command"
 	"github.com/nais/cli/internal/flags"
@@ -71,7 +71,7 @@ func New(w io.Writer) (*Application, *flags.GlobalFlags, error) {
 		activityCommand.Activity(globalFlags),
 		alphaCommand.Alpha(globalFlags),
 		appCommand.App(globalFlags),
-		auth.Auth(globalFlags),
+		authCommand.Auth(globalFlags),
 		configCommand.Config(globalFlags),
 		debugCommand.Debug(globalFlags),
 		issuesCommand.Issues(globalFlags),

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,25 +1,88 @@
 package auth
 
 import (
-	"github.com/nais/cli/internal/auth/flag"
-	"github.com/nais/cli/internal/auth/login"
-	"github.com/nais/cli/internal/auth/logout"
-	"github.com/nais/cli/internal/auth/printaccesstoken"
-	"github.com/nais/cli/internal/flags"
-	"github.com/nais/naistrix"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/nais/cli/internal/naisapi"
+	"github.com/nais/cli/internal/naisapi/gql"
 )
 
-func Auth(parentFlags *flags.GlobalFlags) *naistrix.Command {
-	flags := &flag.Auth{GlobalFlags: parentFlags}
-	return &naistrix.Command{
-		Name:        "auth",
-		Title:       "Authentication",
-		Description: "Commands related to authentication in the nais platform",
-		StickyFlags: flags,
-		SubCommands: []*naistrix.Command{
-			login.Login(flags),
-			logout.Logout(flags),
-			printaccesstoken.PrintAccessToken(flags),
-		},
+// GetEnvironmentOIDCIssuer returns the OIDC issuer URL for workload identity
+// tokens in the given environment.
+func GetEnvironmentOIDCIssuer(ctx context.Context, env string) (*url.URL, error) {
+	_ = `# @genqlient
+		query EnvironmentOIDCIssuer($name: String!) {
+			environment(name: $name) {
+				oidcIssuerURL
+			}
+		}
+	`
+
+	client, err := naisapi.GraphqlClient(ctx)
+	if err != nil {
+		return nil, err
 	}
+
+	resp, err := gql.EnvironmentOIDCIssuer(ctx, client, env)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Environment.OidcIssuerURL == "" {
+		return nil, fmt.Errorf("environment %q does not support workload identity (no OIDC issuer URL)", env)
+	}
+
+	issuer, err := url.Parse(resp.Environment.OidcIssuerURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing OIDC issuer URL %q for environment %q: %w", resp.Environment.OidcIssuerURL, env, err)
+	}
+
+	if issuer.Scheme != "https" || issuer.Host == "" || issuer.RawQuery != "" || issuer.Fragment != "" {
+		return nil, fmt.Errorf("invalid OIDC issuer URL %q for environment %q: expected an absolute https URL without query or fragment", resp.Environment.OidcIssuerURL, env)
+	}
+
+	return issuer, nil
+}
+
+// FetchOIDCDiscoveryDocument resolves the OIDC discovery document for the given
+// issuer URL (by appending /.well-known/openid-configuration) and returns the
+// decoded JSON document.
+func FetchOIDCDiscoveryDocument(ctx context.Context, issuer *url.URL) (any, error) {
+	discoveryURL := issuer.JoinPath(".well-known", "openid-configuration").String()
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, discoveryURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching OIDC discovery document: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetching OIDC discovery document from %s: unexpected status %s: %s", discoveryURL, resp.Status, body)
+	}
+
+	var doc any
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil, fmt.Errorf("OIDC discovery document from %s is not valid JSON: %w", discoveryURL, err)
+	}
+
+	return doc, nil
 }

--- a/internal/auth/command/command.go
+++ b/internal/auth/command/command.go
@@ -1,0 +1,22 @@
+package command
+
+import (
+	"github.com/nais/cli/internal/auth/command/flag"
+	"github.com/nais/cli/internal/flags"
+	"github.com/nais/naistrix"
+)
+
+func Auth(parentFlags *flags.GlobalFlags) *naistrix.Command {
+	f := &flag.Auth{GlobalFlags: parentFlags}
+	return &naistrix.Command{
+		Name:        "auth",
+		Title:       "Authentication",
+		Description: "Commands related to authentication in the nais platform",
+		StickyFlags: f,
+		SubCommands: []*naistrix.Command{
+			login(f),
+			logout(f),
+			printAccessToken(f),
+		},
+	}
+}

--- a/internal/auth/command/command.go
+++ b/internal/auth/command/command.go
@@ -17,6 +17,7 @@ func Auth(parentFlags *flags.GlobalFlags) *naistrix.Command {
 			login(f),
 			logout(f),
 			printAccessToken(f),
+			workloadIdentityMetadata(f),
 		},
 	}
 }

--- a/internal/auth/command/flag/flag.go
+++ b/internal/auth/command/flag/flag.go
@@ -24,3 +24,7 @@ type PrintAccessToken struct {
 	*Auth
 	Nais bool `name:"nais" short:"n" usage:"Print token from login.nais.io instead of gcloud.\nShould be used if you logged in using \"nais login --nais\"."`
 }
+
+type WorkloadIdentityMetadata struct {
+	*Auth
+}

--- a/internal/auth/command/flag/flag.go
+++ b/internal/auth/command/flag/flag.go
@@ -1,0 +1,26 @@
+package flag
+
+import (
+	"github.com/nais/cli/internal/flags"
+)
+
+type Auth struct {
+	*flags.GlobalFlags
+}
+
+type Login struct {
+	*Auth
+	Nais bool `name:"nais" short:"n" usage:"Login using login.nais.io instead of gcloud."`
+	Yes  bool `name:"yes" short:"y" usage:"Automatically answer yes to all prompts."`
+}
+
+type Logout struct {
+	*Auth
+	Nais bool `name:"nais" short:"n" usage:"Logout using login.nais.io instead of gcloud.\nShould be used if you logged in using \"nais login --nais\"."`
+	Yes  bool `name:"yes" short:"y" usage:"Automatically answer yes to all prompts."`
+}
+
+type PrintAccessToken struct {
+	*Auth
+	Nais bool `name:"nais" short:"n" usage:"Print token from login.nais.io instead of gcloud.\nShould be used if you logged in using \"nais login --nais\"."`
+}

--- a/internal/auth/command/login.go
+++ b/internal/auth/command/login.go
@@ -1,10 +1,10 @@
-package login
+package command
 
 import (
 	"context"
 	"os"
 
-	"github.com/nais/cli/internal/auth/flag"
+	"github.com/nais/cli/internal/auth/command/flag"
 	"github.com/nais/cli/internal/gcloud"
 	"github.com/nais/cli/internal/naisapi"
 	"github.com/nais/naistrix"
@@ -12,14 +12,8 @@ import (
 	"golang.org/x/term"
 )
 
-type loginFlags struct {
-	*flag.Auth
-	Nais bool `name:"nais" short:"n" usage:"Login using login.nais.io instead of gcloud."`
-	Yes  bool `name:"yes" short:"y" usage:"Automatically answer yes to all prompts."`
-}
-
-func Login(parentFlags *flag.Auth) *naistrix.Command {
-	flags := &loginFlags{Auth: parentFlags}
+func login(parentFlags *flag.Auth) *naistrix.Command {
+	flags := &flag.Login{Auth: parentFlags}
 	return &naistrix.Command{
 		Name:            "login",
 		Title:           "Log in to the Nais platform.",

--- a/internal/auth/command/logout.go
+++ b/internal/auth/command/logout.go
@@ -1,10 +1,10 @@
-package logout
+package command
 
 import (
 	"context"
 	"os"
 
-	"github.com/nais/cli/internal/auth/flag"
+	"github.com/nais/cli/internal/auth/command/flag"
 	"github.com/nais/cli/internal/gcloud"
 	"github.com/nais/cli/internal/naisapi"
 	"github.com/nais/naistrix"
@@ -12,14 +12,8 @@ import (
 	"golang.org/x/term"
 )
 
-type loginFlags struct {
-	*flag.Auth
-	Nais bool `name:"nais" short:"n" usage:"Logout using login.nais.io instead of gcloud.\nShould be used if you logged in using \"nais login --nais\"."`
-	Yes  bool `name:"yes" short:"y" usage:"Automatically answer yes to all prompts."`
-}
-
-func Logout(parentFlags *flag.Auth) *naistrix.Command {
-	flags := &loginFlags{Auth: parentFlags}
+func logout(parentFlags *flag.Auth) *naistrix.Command {
+	flags := &flag.Logout{Auth: parentFlags}
 	return &naistrix.Command{
 		Name:            "logout",
 		TopLevelAliases: []string{"logout"},

--- a/internal/auth/command/printaccesstoken.go
+++ b/internal/auth/command/printaccesstoken.go
@@ -1,21 +1,16 @@
-package printaccesstoken
+package command
 
 import (
 	"context"
 
-	"github.com/nais/cli/internal/auth/flag"
+	"github.com/nais/cli/internal/auth/command/flag"
 	"github.com/nais/cli/internal/gcloud"
 	"github.com/nais/cli/internal/naisapi"
 	"github.com/nais/naistrix"
 )
 
-type printAccessTokenFlags struct {
-	*flag.Auth
-	Nais bool `name:"nais" short:"n" usage:"Print token from login.nais.io instead of gcloud.\nShould be used if you logged in using \"nais login --nais\"."`
-}
-
-func PrintAccessToken(parentFlags *flag.Auth) *naistrix.Command {
-	flags := &printAccessTokenFlags{Auth: parentFlags}
+func printAccessToken(parentFlags *flag.Auth) *naistrix.Command {
+	flags := &flag.PrintAccessToken{Auth: parentFlags}
 	return &naistrix.Command{
 		Name:        "print-access-token",
 		Title:       "Print current access token",

--- a/internal/auth/command/workloadidentitymetadata.go
+++ b/internal/auth/command/workloadidentitymetadata.go
@@ -1,0 +1,35 @@
+package command
+
+import (
+	"context"
+
+	"github.com/nais/cli/internal/auth"
+	"github.com/nais/cli/internal/auth/command/flag"
+	"github.com/nais/cli/internal/validation"
+	"github.com/nais/naistrix"
+	"github.com/nais/naistrix/output"
+)
+
+func workloadIdentityMetadata(parentFlags *flag.Auth) *naistrix.Command {
+	flags := &flag.WorkloadIdentityMetadata{Auth: parentFlags}
+	return &naistrix.Command{
+		Name:         "workload-identity-metadata",
+		Title:        "Fetch the workload identity OIDC metadata for an environment.",
+		Description:  "Resolves the workload identity OIDC issuer for the selected environment and fetches its metadata from /.well-known/openid-configuration, printing the JSON to stdout.",
+		Flags:        flags,
+		ValidateFunc: validation.RequireEnvironment(flags),
+		RunFunc: func(ctx context.Context, _ *naistrix.Arguments, out *naistrix.OutputWriter) error {
+			issuer, err := auth.GetEnvironmentOIDCIssuer(ctx, string(flags.Environment))
+			if err != nil {
+				return err
+			}
+
+			doc, err := auth.FetchOIDCDiscoveryDocument(ctx, issuer)
+			if err != nil {
+				return err
+			}
+
+			return out.JSON(output.JSONWithPrettyOutput()).Render(doc)
+		},
+	}
+}

--- a/internal/auth/flag/flag.go
+++ b/internal/auth/flag/flag.go
@@ -1,9 +1,0 @@
-package flag
-
-import (
-	"github.com/nais/cli/internal/flags"
-)
-
-type Auth struct {
-	*flags.GlobalFlags
-}

--- a/internal/naisapi/gql/generated.go
+++ b/internal/naisapi/gql/generated.go
@@ -1013,6 +1013,31 @@ func (v *DeleteValkeyResponse) GetDeleteValkey() DeleteValkeyDeleteValkeyDeleteV
 	return v.DeleteValkey
 }
 
+// EnvironmentOIDCIssuerEnvironment includes the requested fields of the GraphQL type Environment.
+// The GraphQL type's documentation follows.
+//
+// An environment represents a runtime environment for workloads.
+//
+// Learn more in the [official Nais documentation](https://docs.nais.io/workloads/explanations/environment/).
+type EnvironmentOIDCIssuerEnvironment struct {
+	// The OIDC issuer URL for workload identity tokens in the environment. Null for environments that do not support workload identity.
+	OidcIssuerURL string `json:"oidcIssuerURL"`
+}
+
+// GetOidcIssuerURL returns EnvironmentOIDCIssuerEnvironment.OidcIssuerURL, and is useful for accessing the field via an interface.
+func (v *EnvironmentOIDCIssuerEnvironment) GetOidcIssuerURL() string { return v.OidcIssuerURL }
+
+// EnvironmentOIDCIssuerResponse is returned by EnvironmentOIDCIssuer on success.
+type EnvironmentOIDCIssuerResponse struct {
+	// Get a single environment.
+	Environment EnvironmentOIDCIssuerEnvironment `json:"environment"`
+}
+
+// GetEnvironment returns EnvironmentOIDCIssuerResponse.Environment, and is useful for accessing the field via an interface.
+func (v *EnvironmentOIDCIssuerResponse) GetEnvironment() EnvironmentOIDCIssuerEnvironment {
+	return v.Environment
+}
+
 // EnvironmentsEnvironmentsEnvironmentConnection includes the requested fields of the GraphQL type EnvironmentConnection.
 // The GraphQL type's documentation follows.
 //
@@ -32506,6 +32531,14 @@ func (v *__DeleteValkeyInput) GetEnvironmentName() string { return v.Environment
 // GetTeamSlug returns __DeleteValkeyInput.TeamSlug, and is useful for accessing the field via an interface.
 func (v *__DeleteValkeyInput) GetTeamSlug() string { return v.TeamSlug }
 
+// __EnvironmentOIDCIssuerInput is used internally by genqlient
+type __EnvironmentOIDCIssuerInput struct {
+	Name string `json:"name"`
+}
+
+// GetName returns __EnvironmentOIDCIssuerInput.Name, and is useful for accessing the field via an interface.
+func (v *__EnvironmentOIDCIssuerInput) GetName() string { return v.Name }
+
 // __FindWorkloadsForCveInput is used internally by genqlient
 type __FindWorkloadsForCveInput struct {
 	Identifier string `json:"identifier"`
@@ -33985,6 +34018,40 @@ func DeleteValkey(
 	}
 
 	data_ = &DeleteValkeyResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
+
+// The query executed by EnvironmentOIDCIssuer.
+const EnvironmentOIDCIssuer_Operation = `
+query EnvironmentOIDCIssuer ($name: String!) {
+	environment(name: $name) {
+		oidcIssuerURL
+	}
+}
+`
+
+func EnvironmentOIDCIssuer(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	name string,
+) (data_ *EnvironmentOIDCIssuerResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "EnvironmentOIDCIssuer",
+		Query:  EnvironmentOIDCIssuer_Operation,
+		Variables: &__EnvironmentOIDCIssuerInput{
+			Name: name,
+		},
+	}
+
+	data_ = &EnvironmentOIDCIssuerResponse{}
 	resp_ := &graphql.Response{Data: data_}
 
 	err_ = client_.MakeRequest(

--- a/schema.graphql
+++ b/schema.graphql
@@ -465,20 +465,6 @@ All activity log entries related to vulnerabilities will use this resource type.
 }
 
 """
-A single facet item for environments.
-"""
-type ActivityLogEnvironmentFacetItem {
-"""
-The environment name.
-"""
-	environmentName: String!
-"""
-Number of matching entries.
-"""
-	count: Int!
-}
-
-"""
 Facets for activity log entries, providing distribution counts across different dimensions.
 """
 type ActivityLogFacets {
@@ -493,7 +479,7 @@ Distribution of entries by resource type.
 """
 Distribution of entries by environment.
 """
-	environments: [ActivityLogEnvironmentFacetItem!]!
+	environments: [StringFacetItem!]!
 }
 
 input ActivityLogFilter {
@@ -1130,27 +1116,13 @@ The application.
 }
 
 """
-A single facet item for environments.
-"""
-type ApplicationEnvironmentFacetItem {
-"""
-The environment name.
-"""
-	environmentName: String!
-"""
-Number of matching applications.
-"""
-	count: Int!
-}
-
-"""
 Facets for applications, providing distribution counts across different dimensions.
 """
 type ApplicationFacets {
 """
 Distribution of applications by environment.
 """
-	environments: [ApplicationEnvironmentFacetItem!]!
+	environments: [StringFacetItem!]!
 """
 Distribution of applications by state.
 """
@@ -1624,6 +1596,11 @@ type BigQueryDatasetConnection {
 	pageInfo: PageInfo!
 	nodes: [BigQueryDataset!]!
 	edges: [BigQueryDatasetEdge!]!
+"""
+Facets for BigQuery datasets. Provides distribution counts to help narrow down results.
+Facet counts are computed over the full result set (ignoring pagination) but respect the current filter.
+"""
+	facets: BigQueryDatasetFacets
 }
 
 type BigQueryDatasetCost {
@@ -1633,6 +1610,30 @@ type BigQueryDatasetCost {
 type BigQueryDatasetEdge {
 	cursor: Cursor!
 	node: BigQueryDataset!
+}
+
+"""
+Facets for BigQuery datasets, providing distribution counts across different dimensions.
+"""
+type BigQueryDatasetFacets {
+"""
+Distribution of datasets by environment.
+"""
+	environments: [StringFacetItem!]!
+}
+
+"""
+Input for filtering BigQuery datasets.
+"""
+input BigQueryDatasetFilter {
+"""
+Input for filtering BigQuery datasets.
+"""
+	name: String
+"""
+Input for filtering BigQuery datasets.
+"""
+	environments: [String!]
 }
 
 input BigQueryDatasetOrder {
@@ -1655,6 +1656,20 @@ The `Boolean` scalar type represents `true` or `false`.
 """
 scalar Boolean
 
+"""
+A shared facet item representing a boolean distribution (e.g., in-use, high availability).
+"""
+type BooleanFacetItem {
+"""
+The boolean value.
+"""
+	value: Boolean!
+"""
+Number of matching resources.
+"""
+	count: Int!
+}
+
 type Bucket implements Persistence & Node{
 	id: ID!
 	name: String!
@@ -1671,11 +1686,40 @@ type BucketConnection {
 	pageInfo: PageInfo!
 	nodes: [Bucket!]!
 	edges: [BucketEdge!]!
+"""
+Facets for buckets. Provides distribution counts to help narrow down results.
+Facet counts are computed over the full result set (ignoring pagination) but respect the current filter.
+"""
+	facets: BucketFacets
 }
 
 type BucketEdge {
 	cursor: Cursor!
 	node: Bucket!
+}
+
+"""
+Facets for buckets, providing distribution counts across different dimensions.
+"""
+type BucketFacets {
+"""
+Distribution of buckets by environment.
+"""
+	environments: [StringFacetItem!]!
+}
+
+"""
+Input for filtering buckets.
+"""
+input BucketFilter {
+"""
+Input for filtering buckets.
+"""
+	name: String
+"""
+Input for filtering buckets.
+"""
+	environments: [String!]
 }
 
 input BucketOrder {
@@ -2009,6 +2053,11 @@ List of nodes.
 List of edges.
 """
 	edges: [ConfigEdge!]!
+"""
+Facets for configs. Provides distribution counts to help narrow down results.
+Facet counts are computed over the full result set (ignoring pagination) but respect the current filter.
+"""
+	facets: ConfigFacets
 }
 
 type ConfigCreatedActivityLogEntry implements ActivityLogEntry & Node{
@@ -2093,6 +2142,20 @@ The Config.
 }
 
 """
+Facets for configs, providing distribution counts across different dimensions.
+"""
+type ConfigFacets {
+"""
+Distribution of configs by environment.
+"""
+	environments: [StringFacetItem!]!
+"""
+Distribution of configs by whether they are in use by any workload.
+"""
+	inUse: [BooleanFacetItem!]!
+}
+
+"""
 Input for filtering the configs of a team.
 """
 input ConfigFilter {
@@ -2104,6 +2167,10 @@ Input for filtering the configs of a team.
 Input for filtering the configs of a team.
 """
 	inUse: Boolean
+"""
+Input for filtering the configs of a team.
+"""
+	environments: [String!]
 }
 
 input ConfigOrder {
@@ -3173,6 +3240,10 @@ The globally unique ID of the team.
 Unique name of the environment.
 """
 	name: String!
+"""
+The OIDC issuer URL for workload identity tokens in the environment. Null for environments that do not support workload identity.
+"""
+	oidcIssuerURL: String
 """
 Query Prometheus metrics directly using PromQL for this environment.
 This allows for flexible metric queries within the specific environment.
@@ -4436,27 +4507,13 @@ The job.
 }
 
 """
-A single facet item for environments.
-"""
-type JobEnvironmentFacetItem {
-"""
-The environment name.
-"""
-	environmentName: String!
-"""
-Number of matching jobs.
-"""
-	count: Int!
-}
-
-"""
 Facets for jobs, providing distribution counts across different dimensions.
 """
 type JobFacets {
 """
 Distribution of jobs by environment.
 """
-	environments: [JobEnvironmentFacetItem!]!
+	environments: [StringFacetItem!]!
 """
 Distribution of jobs by state.
 """
@@ -4959,11 +5016,48 @@ type KafkaTopicConnection {
 	pageInfo: PageInfo!
 	nodes: [KafkaTopic!]!
 	edges: [KafkaTopicEdge!]!
+"""
+Facets for Kafka topics. Provides distribution counts to help narrow down results.
+Facet counts are computed over the full result set (ignoring pagination) but respect the current filter.
+"""
+	facets: KafkaTopicFacets
 }
 
 type KafkaTopicEdge {
 	cursor: Cursor!
 	node: KafkaTopic!
+}
+
+"""
+Facets for Kafka topics, providing distribution counts across different dimensions.
+"""
+type KafkaTopicFacets {
+"""
+Distribution of topics by environment.
+"""
+	environments: [StringFacetItem!]!
+"""
+Distribution of topics by Kafka pool.
+"""
+	pools: [StringFacetItem!]!
+}
+
+"""
+Input for filtering Kafka topics.
+"""
+input KafkaTopicFilter {
+"""
+Input for filtering Kafka topics.
+"""
+	name: String
+"""
+Input for filtering Kafka topics.
+"""
+	environments: [String!]
+"""
+Input for filtering Kafka topics.
+"""
+	pools: [String!]
 }
 
 input KafkaTopicOrder {
@@ -5810,6 +5904,11 @@ type OpenSearchConnection {
 	pageInfo: PageInfo!
 	nodes: [OpenSearch!]!
 	edges: [OpenSearchEdge!]!
+"""
+Facets for OpenSearch instances. Provides distribution counts to help narrow down results.
+Facet counts are computed over the full result set (ignoring pagination) but respect the current filter.
+"""
+	facets: OpenSearchFacets
 }
 
 type OpenSearchCost {
@@ -5912,6 +6011,38 @@ The environment name that the entry belongs to.
 type OpenSearchEdge {
 	cursor: Cursor!
 	node: OpenSearch!
+}
+
+"""
+Facets for OpenSearch instances, providing distribution counts across different dimensions.
+"""
+type OpenSearchFacets {
+"""
+Distribution of instances by environment.
+"""
+	environments: [StringFacetItem!]!
+"""
+Distribution of instances by tier.
+"""
+	tiers: [OpenSearchTierFacetItem!]!
+}
+
+"""
+Input for filtering OpenSearch instances.
+"""
+input OpenSearchFilter {
+"""
+Input for filtering OpenSearch instances.
+"""
+	name: String
+"""
+Input for filtering OpenSearch instances.
+"""
+	environments: [String!]
+"""
+Input for filtering OpenSearch instances.
+"""
+	tiers: [OpenSearchTier!]
 }
 
 type OpenSearchIssue implements Issue & Node{
@@ -6047,6 +6178,20 @@ enum OpenSearchState {
 enum OpenSearchTier {
 	SINGLE_NODE
 	HIGH_AVAILABILITY
+}
+
+"""
+A single facet item for OpenSearch tiers.
+"""
+type OpenSearchTierFacetItem {
+"""
+The OpenSearch tier.
+"""
+	tier: OpenSearchTier!
+"""
+Number of matching instances.
+"""
+	count: Int!
 }
 
 type OpenSearchUpdatedActivityLogEntry implements ActivityLogEntry & Node{
@@ -6332,11 +6477,64 @@ type PostgresInstanceConnection {
 	pageInfo: PageInfo!
 	nodes: [PostgresInstance!]!
 	edges: [PostgresInstanceEdge!]!
+"""
+Facets for Postgres instances. Provides distribution counts to help narrow down results.
+Facet counts are computed over the full result set (ignoring pagination) but respect the current filter.
+"""
+	facets: PostgresInstanceFacets
 }
 
 type PostgresInstanceEdge {
 	cursor: Cursor!
 	node: PostgresInstance!
+}
+
+"""
+Facets for Postgres instances, providing distribution counts across different dimensions.
+"""
+type PostgresInstanceFacets {
+"""
+Distribution of instances by environment.
+"""
+	environments: [StringFacetItem!]!
+"""
+Distribution of instances by state.
+"""
+	states: [PostgresInstanceStateFacetItem!]!
+"""
+Distribution of instances by high availability.
+"""
+	highAvailability: [BooleanFacetItem!]!
+"""
+Distribution of instances by major version.
+"""
+	majorVersions: [StringFacetItem!]!
+}
+
+"""
+Input for filtering Postgres instances.
+"""
+input PostgresInstanceFilter {
+"""
+Input for filtering Postgres instances.
+"""
+	name: String
+"""
+Input for filtering Postgres instances.
+"""
+	environments: [String!]
+"""
+Input for filtering Postgres instances.
+"""
+	states: [PostgresInstanceState!]
+"""
+Input for filtering Postgres instances.
+"""
+	highAvailability: Boolean
+"""
+Input for filtering Postgres instances.
+"""
+	majorVersions: [String!]
 }
 
 type PostgresInstanceMaintenanceWindow {
@@ -6364,6 +6562,20 @@ enum PostgresInstanceState {
 	AVAILABLE
 	PROGRESSING
 	DEGRADED
+}
+
+"""
+A single facet item for Postgres instance states.
+"""
+type PostgresInstanceStateFacetItem {
+"""
+The Postgres instance state.
+"""
+	state: PostgresInstanceState!
+"""
+Number of matching instances.
+"""
+	count: Int!
 }
 
 type Price {
@@ -7827,6 +8039,11 @@ List of nodes.
 List of edges.
 """
 	edges: [SecretEdge!]!
+"""
+Facets for secrets. Provides distribution counts to help narrow down results.
+Facet counts are computed over the full result set (ignoring pagination) but respect the current filter.
+"""
+	facets: SecretFacets
 }
 
 type SecretCreatedActivityLogEntry implements ActivityLogEntry & Node{
@@ -7911,6 +8128,20 @@ The Secret.
 }
 
 """
+Facets for secrets, providing distribution counts across different dimensions.
+"""
+type SecretFacets {
+"""
+Distribution of secrets by environment.
+"""
+	environments: [StringFacetItem!]!
+"""
+Distribution of secrets by whether they are in use by any workload.
+"""
+	inUse: [BooleanFacetItem!]!
+}
+
+"""
 Input for filtering the secrets of a team.
 """
 input SecretFilter {
@@ -7922,6 +8153,10 @@ Input for filtering the secrets of a team.
 Input for filtering the secrets of a team.
 """
 	inUse: Boolean
+"""
+Input for filtering the secrets of a team.
+"""
+	environments: [String!]
 }
 
 input SecretOrder {
@@ -9155,6 +9390,20 @@ The `String`scalar type represents textual data, represented as UTF-8 character 
 scalar String
 
 """
+A shared facet item representing a string value distribution (e.g., pool name, version).
+"""
+type StringFacetItem {
+"""
+The string value.
+"""
+	value: String!
+"""
+Number of matching resources.
+"""
+	count: Int!
+}
+
+"""
 The subscription root for the Nais GraphQL API.
 """
 type Subscription {
@@ -9380,6 +9629,10 @@ Get items before this cursor.
 Ordering options for items returned from the connection.
 """
 		orderBy: BigQueryDatasetOrder
+"""
+Filtering options for items returned from the connection.
+"""
+		filter: BigQueryDatasetFilter
 	): BigQueryDatasetConnection!
 """
 Google Cloud Storage buckets owned by the team.
@@ -9405,6 +9658,10 @@ Get items before this cursor.
 Ordering options for items returned from the connection.
 """
 		orderBy: BucketOrder
+"""
+Filtering options for items returned from the connection.
+"""
+		filter: BucketFilter
 	): BucketConnection!
 """
 Configs owned by the team.
@@ -9540,6 +9797,10 @@ Get items before this cursor.
 Ordering options for items returned from the connection.
 """
 		orderBy: KafkaTopicOrder
+"""
+Filtering options for items returned from the connection.
+"""
+		filter: KafkaTopicFilter
 	): KafkaTopicConnection!
 """
 OpenSearch instances owned by the team.
@@ -9565,6 +9826,10 @@ Get items before this cursor.
 Ordering options for items returned from the connection.
 """
 		orderBy: OpenSearchOrder
+"""
+Filtering options for items returned from the connection.
+"""
+		filter: OpenSearchFilter
 	): OpenSearchConnection!
 """
 Postgres instances owned by the team.
@@ -9590,6 +9855,10 @@ Get items before this cursor.
 Ordering options for items returned from the connection.
 """
 		orderBy: PostgresInstanceOrder
+"""
+Filtering options for items returned from the connection.
+"""
+		filter: PostgresInstanceFilter
 	): PostgresInstanceConnection!
 	repositories(
 """
@@ -9718,6 +9987,10 @@ Get items before this cursor.
 Ordering options for items returned from the connection.
 """
 		orderBy: ValkeyOrder
+"""
+Filtering options for items returned from the connection.
+"""
+		filter: ValkeyFilter
 	): ValkeyConnection!
 """
 Get the vulnerability summary history for team.
@@ -12143,6 +12416,11 @@ type ValkeyConnection {
 	pageInfo: PageInfo!
 	nodes: [Valkey!]!
 	edges: [ValkeyEdge!]!
+"""
+Facets for Valkey instances. Provides distribution counts to help narrow down results.
+Facet counts are computed over the full result set (ignoring pagination) but respect the current filter.
+"""
+	facets: ValkeyFacets
 }
 
 type ValkeyCost {
@@ -12245,6 +12523,38 @@ The environment name that the entry belongs to.
 type ValkeyEdge {
 	cursor: Cursor!
 	node: Valkey!
+}
+
+"""
+Facets for Valkey instances, providing distribution counts across different dimensions.
+"""
+type ValkeyFacets {
+"""
+Distribution of instances by environment.
+"""
+	environments: [StringFacetItem!]!
+"""
+Distribution of instances by tier.
+"""
+	tiers: [ValkeyTierFacetItem!]!
+}
+
+"""
+Input for filtering Valkey instances.
+"""
+input ValkeyFilter {
+"""
+Input for filtering Valkey instances.
+"""
+	name: String
+"""
+Input for filtering Valkey instances.
+"""
+	environments: [String!]
+"""
+Input for filtering Valkey instances.
+"""
+	tiers: [ValkeyTier!]
 }
 
 type ValkeyIssue implements Issue & Node{
@@ -12398,6 +12708,20 @@ enum ValkeyState {
 enum ValkeyTier {
 	SINGLE_NODE
 	HIGH_AVAILABILITY
+}
+
+"""
+A single facet item for Valkey tiers.
+"""
+type ValkeyTierFacetItem {
+"""
+The Valkey tier.
+"""
+	tier: ValkeyTier!
+"""
+Number of matching instances.
+"""
+	count: Int!
 }
 
 type ValkeyUpdatedActivityLogEntry implements ActivityLogEntry & Node{


### PR DESCRIPTION
Add "nais auth workload-identity-metadata" which resolves the workload
identity OIDC issuer for the selected environment via the API and fetches
its discovery document from /.well-known/openid-configuration, printing
the JSON to stdout.

Merge the separate login, logout, printaccesstoken and flag packages
into one internal/auth/command package, mirroring the structure used by
other domains.