### PR TITLE
feat(apply): Infer missing workload image from cluster

### DIFF
--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -62,6 +62,12 @@ func Run(ctx context.Context, filePath string, flags *flag.Apply, out *naistrix.
 				errs = append(errs, err.Error())
 				continue
 			}
+
+			if err := ensureWorkloadImage(ctx, &crd, flags.Team, environment, out); err != nil {
+				errs = append(errs, err.Error())
+				continue
+			}
+
 			crds = append(crds, crd)
 			r, _ := resource.ForCRD(crd.GetAPIVersion(), crd.GetKind())
 			waitTargets = appendWaitTarget(waitTargets, r, crd.GetName())
@@ -103,6 +109,12 @@ func Run(ctx context.Context, filePath string, flags *flag.Apply, out *naistrix.
 			errs = append(errs, fmt.Sprintf("%s/%s: %v", m.Kind, m.Name, err))
 			continue
 		}
+
+		if err := ensureWorkloadImage(ctx, &crd, flags.Team, environment, out); err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+
 		crds = append(crds, crd)
 		waitTargets = appendWaitTarget(waitTargets, r, m.Name)
 	}
@@ -231,6 +243,45 @@ func toUnstructured(m resource.Manifest, r resource.Resource) (unstructured.Unst
 		"metadata":   map[string]any{"name": m.Name},
 		"spec":       spec,
 	}}, nil
+}
+
+// workloadKinds are the CRD kinds that require a spec.image field.
+var workloadKinds = map[string]bool{
+	"Application": true,
+	"Naisjob":     true,
+}
+
+// ensureWorkloadImage checks whether an Application or Naisjob CRD has spec.image
+// set. When it is missing, the current image is fetched from the cluster and
+// injected into the manifest. An error is returned when the image cannot be
+// resolved (e.g. the workload does not exist in the cluster yet).
+func ensureWorkloadImage(ctx context.Context, crd *unstructured.Unstructured, team, environment string, out *naistrix.OutputWriter) error {
+	kind := crd.GetKind()
+	if !workloadKinds[kind] {
+		return nil
+	}
+
+	// If the manifest already contains spec.image, there is nothing to do.
+	if img, _, _ := unstructured.NestedString(crd.Object, "spec", "image"); img != "" {
+		return nil
+	}
+
+	name := crd.GetName()
+	image, err := getWorkloadImage(ctx, team, environment, name, kind)
+	if err != nil {
+		return fmt.Errorf(
+			"%s/%s is missing spec.image and the current image could not be fetched from the cluster: %w\n"+
+				"Set the image in the manifest or pass --set spec.image=<image>",
+			kind, name, err,
+		)
+	}
+
+	if err := unstructured.SetNestedField(crd.Object, image.String(), "spec", "image"); err != nil {
+		return fmt.Errorf("failed to set spec.image on %s/%s: %w", kind, name, err)
+	}
+
+	out.Printf("%s/%s: spec.image not set, using current image from cluster: %s\n", kind, name, image)
+	return nil
 }
 
 // readManifestFile reads a YAML manifest file, validating the extension.

--- a/internal/apply/image.go
+++ b/internal/apply/image.go
@@ -1,0 +1,95 @@
+package apply
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nais/cli/internal/naisapi"
+	"github.com/nais/cli/internal/naisapi/gql"
+)
+
+// workloadImage holds the resolved container image for a workload.
+type workloadImage struct {
+	name string
+	tag  string
+}
+
+func (w workloadImage) String() string {
+	if w.tag != "" {
+		return w.name + ":" + w.tag
+	}
+	return w.name
+}
+
+// getWorkloadImage fetches the current container image for a workload (Application
+// or Job) from the cluster via the nais API.
+func getWorkloadImage(ctx context.Context, team, environment, name, kind string) (workloadImage, error) {
+	switch kind {
+	case "Application":
+		return getApplicationImage(ctx, team, environment, name)
+	case "Naisjob":
+		return getJobImage(ctx, team, environment, name)
+	default:
+		return workloadImage{}, fmt.Errorf("unsupported workload kind %q", kind)
+	}
+}
+
+func getApplicationImage(ctx context.Context, team, environment, name string) (workloadImage, error) {
+	_ = `# @genqlient
+		query GetCurrentApplicationImage($team: Slug!, $environment: String!, $name: String!) {
+		  team(slug: $team) {
+		    environment(name: $environment) {
+		      application(name: $name) {
+		        image {
+		          name
+		          tag
+		        }
+		      }
+		    }
+		  }
+		}
+	`
+
+	client, err := naisapi.GraphqlClient(ctx)
+	if err != nil {
+		return workloadImage{}, err
+	}
+
+	resp, err := gql.GetCurrentApplicationImage(ctx, client, team, environment, name)
+	if err != nil {
+		return workloadImage{}, err
+	}
+
+	img := resp.Team.Environment.Application.Image
+	return workloadImage{name: img.Name, tag: img.Tag}, nil
+}
+
+func getJobImage(ctx context.Context, team, environment, name string) (workloadImage, error) {
+	_ = `# @genqlient
+		query GetCurrentJobImage($team: Slug!, $environment: String!, $name: String!) {
+		  team(slug: $team) {
+		    environment(name: $environment) {
+		      job(name: $name) {
+		        image {
+		          name
+		          tag
+		        }
+		      }
+		    }
+		  }
+		}
+	`
+
+	client, err := naisapi.GraphqlClient(ctx)
+	if err != nil {
+		return workloadImage{}, err
+	}
+
+	resp, err := gql.GetCurrentJobImage(ctx, client, team, environment, name)
+	if err != nil {
+		return workloadImage{}, err
+	}
+
+	img := resp.Team.Environment.Job.Image
+	return workloadImage{name: img.Name, tag: img.Tag}, nil
+}

--- a/internal/naisapi/gql/generated.go
+++ b/internal/naisapi/gql/generated.go
@@ -14112,6 +14112,147 @@ func __marshalGetConfigTeamEnvironmentConfigWorkloadsWorkloadConnectionNodesWork
 	}
 }
 
+// GetCurrentApplicationImageResponse is returned by GetCurrentApplicationImage on success.
+type GetCurrentApplicationImageResponse struct {
+	// Get a team by its slug.
+	Team GetCurrentApplicationImageTeam `json:"team"`
+}
+
+// GetTeam returns GetCurrentApplicationImageResponse.Team, and is useful for accessing the field via an interface.
+func (v *GetCurrentApplicationImageResponse) GetTeam() GetCurrentApplicationImageTeam { return v.Team }
+
+// GetCurrentApplicationImageTeam includes the requested fields of the GraphQL type Team.
+// The GraphQL type's documentation follows.
+//
+// The team type represents a team on the [Nais platform](https://nais.io/).
+//
+// Learn more about what Nais teams are and what they can be used for in the [official Nais documentation](https://docs.nais.io/explanations/team/).
+//
+// External resources (e.g. entraIDGroupID, gitHubTeamSlug) are managed by [Nais API reconcilers](https://github.com/nais/api-reconcilers).
+type GetCurrentApplicationImageTeam struct {
+	// Get a specific environment for the team.
+	Environment GetCurrentApplicationImageTeamEnvironment `json:"environment"`
+}
+
+// GetEnvironment returns GetCurrentApplicationImageTeam.Environment, and is useful for accessing the field via an interface.
+func (v *GetCurrentApplicationImageTeam) GetEnvironment() GetCurrentApplicationImageTeamEnvironment {
+	return v.Environment
+}
+
+// GetCurrentApplicationImageTeamEnvironment includes the requested fields of the GraphQL type TeamEnvironment.
+type GetCurrentApplicationImageTeamEnvironment struct {
+	// Nais application in the team environment.
+	Application GetCurrentApplicationImageTeamEnvironmentApplication `json:"application"`
+}
+
+// GetApplication returns GetCurrentApplicationImageTeamEnvironment.Application, and is useful for accessing the field via an interface.
+func (v *GetCurrentApplicationImageTeamEnvironment) GetApplication() GetCurrentApplicationImageTeamEnvironmentApplication {
+	return v.Application
+}
+
+// GetCurrentApplicationImageTeamEnvironmentApplication includes the requested fields of the GraphQL type Application.
+// The GraphQL type's documentation follows.
+//
+// An application lets you run one or more instances of a container image on the [Nais platform](https://nais.io/).
+//
+// Learn more about how to create and configure your applications in the [Nais documentation](https://docs.nais.io/workloads/application/).
+type GetCurrentApplicationImageTeamEnvironmentApplication struct {
+	// The container image of the application.
+	Image GetCurrentApplicationImageTeamEnvironmentApplicationImageContainerImage `json:"image"`
+}
+
+// GetImage returns GetCurrentApplicationImageTeamEnvironmentApplication.Image, and is useful for accessing the field via an interface.
+func (v *GetCurrentApplicationImageTeamEnvironmentApplication) GetImage() GetCurrentApplicationImageTeamEnvironmentApplicationImageContainerImage {
+	return v.Image
+}
+
+// GetCurrentApplicationImageTeamEnvironmentApplicationImageContainerImage includes the requested fields of the GraphQL type ContainerImage.
+// The GraphQL type's documentation follows.
+//
+// Container image.
+type GetCurrentApplicationImageTeamEnvironmentApplicationImageContainerImage struct {
+	// Name of the container image.
+	Name string `json:"name"`
+	// Tag of the container image.
+	Tag string `json:"tag"`
+}
+
+// GetName returns GetCurrentApplicationImageTeamEnvironmentApplicationImageContainerImage.Name, and is useful for accessing the field via an interface.
+func (v *GetCurrentApplicationImageTeamEnvironmentApplicationImageContainerImage) GetName() string {
+	return v.Name
+}
+
+// GetTag returns GetCurrentApplicationImageTeamEnvironmentApplicationImageContainerImage.Tag, and is useful for accessing the field via an interface.
+func (v *GetCurrentApplicationImageTeamEnvironmentApplicationImageContainerImage) GetTag() string {
+	return v.Tag
+}
+
+// GetCurrentJobImageResponse is returned by GetCurrentJobImage on success.
+type GetCurrentJobImageResponse struct {
+	// Get a team by its slug.
+	Team GetCurrentJobImageTeam `json:"team"`
+}
+
+// GetTeam returns GetCurrentJobImageResponse.Team, and is useful for accessing the field via an interface.
+func (v *GetCurrentJobImageResponse) GetTeam() GetCurrentJobImageTeam { return v.Team }
+
+// GetCurrentJobImageTeam includes the requested fields of the GraphQL type Team.
+// The GraphQL type's documentation follows.
+//
+// The team type represents a team on the [Nais platform](https://nais.io/).
+//
+// Learn more about what Nais teams are and what they can be used for in the [official Nais documentation](https://docs.nais.io/explanations/team/).
+//
+// External resources (e.g. entraIDGroupID, gitHubTeamSlug) are managed by [Nais API reconcilers](https://github.com/nais/api-reconcilers).
+type GetCurrentJobImageTeam struct {
+	// Get a specific environment for the team.
+	Environment GetCurrentJobImageTeamEnvironment `json:"environment"`
+}
+
+// GetEnvironment returns GetCurrentJobImageTeam.Environment, and is useful for accessing the field via an interface.
+func (v *GetCurrentJobImageTeam) GetEnvironment() GetCurrentJobImageTeamEnvironment {
+	return v.Environment
+}
+
+// GetCurrentJobImageTeamEnvironment includes the requested fields of the GraphQL type TeamEnvironment.
+type GetCurrentJobImageTeamEnvironment struct {
+	// Nais job in the team environment.
+	Job GetCurrentJobImageTeamEnvironmentJob `json:"job"`
+}
+
+// GetJob returns GetCurrentJobImageTeamEnvironment.Job, and is useful for accessing the field via an interface.
+func (v *GetCurrentJobImageTeamEnvironment) GetJob() GetCurrentJobImageTeamEnvironmentJob {
+	return v.Job
+}
+
+// GetCurrentJobImageTeamEnvironmentJob includes the requested fields of the GraphQL type Job.
+type GetCurrentJobImageTeamEnvironmentJob struct {
+	// The container image of the job.
+	Image GetCurrentJobImageTeamEnvironmentJobImageContainerImage `json:"image"`
+}
+
+// GetImage returns GetCurrentJobImageTeamEnvironmentJob.Image, and is useful for accessing the field via an interface.
+func (v *GetCurrentJobImageTeamEnvironmentJob) GetImage() GetCurrentJobImageTeamEnvironmentJobImageContainerImage {
+	return v.Image
+}
+
+// GetCurrentJobImageTeamEnvironmentJobImageContainerImage includes the requested fields of the GraphQL type ContainerImage.
+// The GraphQL type's documentation follows.
+//
+// Container image.
+type GetCurrentJobImageTeamEnvironmentJobImageContainerImage struct {
+	// Name of the container image.
+	Name string `json:"name"`
+	// Tag of the container image.
+	Tag string `json:"tag"`
+}
+
+// GetName returns GetCurrentJobImageTeamEnvironmentJobImageContainerImage.Name, and is useful for accessing the field via an interface.
+func (v *GetCurrentJobImageTeamEnvironmentJobImageContainerImage) GetName() string { return v.Name }
+
+// GetTag returns GetCurrentJobImageTeamEnvironmentJobImageContainerImage.Tag, and is useful for accessing the field via an interface.
+func (v *GetCurrentJobImageTeamEnvironmentJobImageContainerImage) GetTag() string { return v.Tag }
+
 // GetJobActivityResponse is returned by GetJobActivity on success.
 type GetJobActivityResponse struct {
 	// Get a team by its slug.
@@ -33309,6 +33450,38 @@ func (v *__GetConfigInput) GetEnvironmentName() string { return v.EnvironmentNam
 // GetTeamSlug returns __GetConfigInput.TeamSlug, and is useful for accessing the field via an interface.
 func (v *__GetConfigInput) GetTeamSlug() string { return v.TeamSlug }
 
+// __GetCurrentApplicationImageInput is used internally by genqlient
+type __GetCurrentApplicationImageInput struct {
+	Team        string `json:"team"`
+	Environment string `json:"environment"`
+	Name        string `json:"name"`
+}
+
+// GetTeam returns __GetCurrentApplicationImageInput.Team, and is useful for accessing the field via an interface.
+func (v *__GetCurrentApplicationImageInput) GetTeam() string { return v.Team }
+
+// GetEnvironment returns __GetCurrentApplicationImageInput.Environment, and is useful for accessing the field via an interface.
+func (v *__GetCurrentApplicationImageInput) GetEnvironment() string { return v.Environment }
+
+// GetName returns __GetCurrentApplicationImageInput.Name, and is useful for accessing the field via an interface.
+func (v *__GetCurrentApplicationImageInput) GetName() string { return v.Name }
+
+// __GetCurrentJobImageInput is used internally by genqlient
+type __GetCurrentJobImageInput struct {
+	Team        string `json:"team"`
+	Environment string `json:"environment"`
+	Name        string `json:"name"`
+}
+
+// GetTeam returns __GetCurrentJobImageInput.Team, and is useful for accessing the field via an interface.
+func (v *__GetCurrentJobImageInput) GetTeam() string { return v.Team }
+
+// GetEnvironment returns __GetCurrentJobImageInput.Environment, and is useful for accessing the field via an interface.
+func (v *__GetCurrentJobImageInput) GetEnvironment() string { return v.Environment }
+
+// GetName returns __GetCurrentJobImageInput.Name, and is useful for accessing the field via an interface.
+func (v *__GetCurrentJobImageInput) GetName() string { return v.Name }
+
 // __GetJobActivityInput is used internally by genqlient
 type __GetJobActivityInput struct {
 	Team  string   `json:"team"`
@@ -35622,6 +35795,96 @@ func GetConfigActivity(
 	}
 
 	data_ = &GetConfigActivityResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
+
+// The query executed by GetCurrentApplicationImage.
+const GetCurrentApplicationImage_Operation = `
+query GetCurrentApplicationImage ($team: Slug!, $environment: String!, $name: String!) {
+	team(slug: $team) {
+		environment(name: $environment) {
+			application(name: $name) {
+				image {
+					name
+					tag
+				}
+			}
+		}
+	}
+}
+`
+
+func GetCurrentApplicationImage(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	team string,
+	environment string,
+	name string,
+) (data_ *GetCurrentApplicationImageResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "GetCurrentApplicationImage",
+		Query:  GetCurrentApplicationImage_Operation,
+		Variables: &__GetCurrentApplicationImageInput{
+			Team:        team,
+			Environment: environment,
+			Name:        name,
+		},
+	}
+
+	data_ = &GetCurrentApplicationImageResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
+
+// The query executed by GetCurrentJobImage.
+const GetCurrentJobImage_Operation = `
+query GetCurrentJobImage ($team: Slug!, $environment: String!, $name: String!) {
+	team(slug: $team) {
+		environment(name: $environment) {
+			job(name: $name) {
+				image {
+					name
+					tag
+				}
+			}
+		}
+	}
+}
+`
+
+func GetCurrentJobImage(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	team string,
+	environment string,
+	name string,
+) (data_ *GetCurrentJobImageResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "GetCurrentJobImage",
+		Query:  GetCurrentJobImage_Operation,
+		Variables: &__GetCurrentJobImageInput{
+			Team:        team,
+			Environment: environment,
+			Name:        name,
+		},
+	}
+
+	data_ = &GetCurrentJobImageResponse{}
 	resp_ := &graphql.Response{Data: data_}
 
 	err_ = client_.MakeRequest(


### PR DESCRIPTION
When applying Application and Naisjob manifests without `spec.image`, fetch the current image via nais-api GraphQL and inject it before apply. Return a clear error if the image cannot be resolved.