### PR TITLE
fix(keyring): bump keyring operation timeout from 3s to 60s

### DIFF
--- a/internal/keyring/keyring.go
+++ b/internal/keyring/keyring.go
@@ -49,7 +49,7 @@ func Get() (string, error) {
 			return "", ErrSecretNotFound
 		}
 		return res.val, res.err
-	case <-time.After(3 * time.Second):
+	case <-time.After(60 * time.Second):
 		return "", &TimeoutError{"timeout while trying to get secret from keyring"}
 	}
 }
@@ -76,7 +76,7 @@ func Set(value string) error {
 	select {
 	case err := <-ch:
 		return err
-	case <-time.After(3 * time.Second):
+	case <-time.After(60 * time.Second):
 		return &TimeoutError{"timeout while trying to set secret in keyring"}
 	}
 }
@@ -97,7 +97,7 @@ func Delete() error {
 			return ErrSecretNotFound
 		}
 		return err
-	case <-time.After(3 * time.Second):
+	case <-time.After(60 * time.Second):
 		return &TimeoutError{"timeout while trying to delete keyring secrets for service"}
 	}
 }


### PR DESCRIPTION
## Problem

On macOS, `zalando/go-keyring` shells out to `/usr/bin/security`, which can trigger an interactive keychain prompt — for example when the `cli.nais.io` keychain item's ACL is set to require the keychain password per access (a common workstation-hardening setup), or after a Homebrew upgrade changes the binary so the ACL no longer matches.

`internal/keyring/keyring.go` wraps every keyring operation in a hardcoded 3-second timeout, so every authenticated command fails with

```
creating GraphQL client: get encryption key: timeout while trying to get secret from keyring
```

before the user can possibly type their password. The abandoned goroutine also orphans the `security` process, leaving a stale password prompt on screen after the CLI has exited.

## Fix

Bump the timeout from 3s to 60s in `Get`, `Set` and `Delete`.

This mirrors upstream: the file is borrowed from `cli/cli`, which made the exact same change for the same reason in cli/cli@0ca080da ("Bump keyring operation timeout from 3s to 60s — the 3-second timeout doesn't leave enough time to respond to an interactive unlock prompt").

The timeout still guards against a genuinely hung keyring backend (the original motivation, cli/cli#7580); it just no longer races the user's typing speed.

## Repro

1. In Keychain Access, set "Ask for keychain password" on the `cli.nais.io` item's access control.
2. Run any authenticated command, e.g. `nais postgres proxy …`.
3. Before this change: fails after 3s while the password prompt is still open. After: the prompt can be answered normally.
